### PR TITLE
Reduce temporary variables

### DIFF
--- a/eudplib/core/variable/vbase.py
+++ b/eudplib/core/variable/vbase.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 """
 
 from .. import rawtrigger as bt
+from ..allocator import IsConstExpr
 from eudplib import utils as ut
 from eudplib.localize import _
 
@@ -120,8 +121,8 @@ class VariableBase:
         "In-place invert (x << ~x)"
         return self.__ixor__(0xFFFFFFFF)
 
-    def inot(self):
-        "In-place not (x << -x)"
+    def ineg(self):
+        "In-place negate (x << -x)"
         bt.RawTrigger(
             actions=[
                 self.AddNumberX(0xFFFFFFFF, 0x55555555),
@@ -158,8 +159,26 @@ class VariableBase:
     def __eq__(self, other):
         return self.Exactly(other)
 
+    def __ne__(self, other):
+        if isinstance(other, int):
+            if other & 0xFFFFFFFF == 0:
+                return self.AtLeast(1)
+            if other & 0xFFFFFFFF == 0xFFFFFFFF:
+                return self.AtMost(0xFFFFFFFE)
+        return NotImplemented
+
     def __le__(self, other):
         return self.AtMost(other)
 
+    def __lt__(self, other):
+        if IsConstExpr(other):
+            return self.AtMost(other - 1)
+        return NotImplemented
+
     def __ge__(self, other):
         return self.AtLeast(other)
+
+    def __gt__(self, other):
+        if IsConstExpr(other):
+            return self.AtLeast(other + 1)
+        return NotImplemented


### PR DESCRIPTION
https://github.com/armoha/eudplib/blob/db3e0b09748c6582b43118c0073faf84d726a286/eudplib/core/variable/eudv.py#L128-L129
`IsRValue` checks whether variable has any reference.

If `var a` has no reference, we can converts `a + b` into `a += b`.
Converting operation to in-place operation saves lots of triggers and actions.
- `var + var` to `var += var` (3T8A to 2T4A)
- `var + const` to `var += const` (2T5A to 1A)
- `var - var` to `var -= var` (4T10A to 3T9A or 2T7A)
  (3T 9A)
  https://github.com/armoha/eudplib/blob/a919af4f950488236db755d14421f1b1e1cc70d1/eudplib/core/variable/eudv.py#L252-L259
  (2T 7A)
  https://github.com/armoha/eudplib/blob/a919af4f950488236db755d14421f1b1e1cc70d1/eudplib/core/variable/eudv.py#L282-L290
- `var - const` to `var -= const` (2T5A to 1A)
- `const - var` to `-var += const` (3T6A to 3A)
  https://github.com/armoha/eudplib/blob/a919af4f950488236db755d14421f1b1e1cc70d1/eudplib/core/variable/eudv.py#L316-L322
- `-var` (3T6A to 3A)
  https://github.com/armoha/eudplib/blob/a919af4f950488236db755d14421f1b1e1cc70d1/eudplib/core/variable/vbase.py#L126-L132
- `~var` (2T5A to 2A)