### PR TITLE
Split into EUDCustomVarBuffer

### DIFF
--- a/eudplib/core/eudstruct/vararray.py
+++ b/eudplib/core/eudstruct/vararray.py
@@ -30,6 +30,7 @@ from ...localize import _
 from ...utils import EPD, ExprProxy, ep_assert, cachedfunc, isUnproxyInstance, ep_assert
 
 from ..variable import EUDVariable, SeqCompute, VProc, IsEUDVariable
+from ..variable.eudv import _ProcessDest
 from ..variable.vbuf import GetCurrentVariableBuffer, GetCurrentCustomVariableBuffer
 
 
@@ -38,12 +39,17 @@ def EUDVArrayData(size):
     ep_assert(isinstance(size, int))
 
     class _EUDVArrayData(ConstExpr):
-        def __init__(self, initvars):
+        def __init__(self, initvars, *, dest=0, nextptr=0):
             super().__init__(self)
             ep_assert(
                 len(initvars) == size,
                 _("{} items expected, got {}").format(size, len(initvars)),
             )
+            if dest != 0 or nextptr != 0:
+                initvars = [
+                    (0xFFFFFFFF, _ProcessDest(dest), initvar, 0x072D0000, nextptr)
+                    for initvar in initvars
+                ]
             self._initvars = initvars
 
         def Evaluate(self):

--- a/eudplib/core/eudstruct/vararray.py
+++ b/eudplib/core/eudstruct/vararray.py
@@ -30,7 +30,7 @@ from ...localize import _
 from ...utils import EPD, ExprProxy, ep_assert, cachedfunc, isUnproxyInstance, ep_assert
 
 from ..variable import EUDVariable, SeqCompute, VProc, IsEUDVariable
-from ..variable.vbuf import GetCurrentVariableBuffer
+from ..variable.vbuf import GetCurrentVariableBuffer, GetCurrentCustomVariableBuffer
 
 
 @cachedfunc
@@ -47,7 +47,10 @@ def EUDVArrayData(size):
             self._initvars = initvars
 
         def Evaluate(self):
-            evb = GetCurrentVariableBuffer()
+            if all(isinstance(var, tuple) for var in self._initvars):
+                evb = GetCurrentCustomVariableBuffer()
+            else:
+                evb = GetCurrentVariableBuffer()
             if self not in evb._vdict:
                 evb.CreateMultipleVarTriggers(self, self._initvars)
 
@@ -111,11 +114,11 @@ def EUDVArray(size, basetype=None):
 
                 for t in range(31, -1, -1):
                     _goto_getidx[t] << bt.RawTrigger(
-                        conditions=_index.AtLeastX(1, 2 ** t),
+                        conditions=_index.AtLeastX(1, 2**t),
                         actions=[
-                            bt.SetMemory(_end_getidx + 4, bt.Add, 72 * (2 ** t)),
-                            bt.SetMemory(_ret_getidx + 16, bt.Add, 18 * (2 ** t)),
-                            bt.SetMemory(_ret_getidx + 48, bt.Add, 18 * (2 ** t)),
+                            bt.SetMemory(_end_getidx + 4, bt.Add, 72 * (2**t)),
+                            bt.SetMemory(_ret_getidx + 16, bt.Add, 18 * (2**t)),
+                            bt.SetMemory(_ret_getidx + 48, bt.Add, 18 * (2**t)),
                         ],
                     )
                 _end_getidx << bt.RawTrigger(

--- a/eudplib/core/variable/eudv.py
+++ b/eudplib/core/variable/eudv.py
@@ -88,9 +88,16 @@ class EUDVariable(VariableBase):
     Full variable.
     """
 
-    def __init__(self, _initval=0, modifier=bt.SetTo, /, initval=0, *, nextptr=0):
-        if not (modifier == bt.SetTo and initval == 0 and nextptr == 0):
-            modifier = ((bt.EncodeModifier(modifier) & 0xFF) << 24) + 0x2D0000
+    def __init__(self, _initval=0, modifier=None, /, initval=None, *, nextptr=None):
+        if not (modifier is None and initval is None and nextptr is None):
+            if modifier is None:
+                modifier = 0x072D0000
+            else:
+                modifier = ((bt.EncodeModifier(modifier) & 0xFF) << 24) | 0x2D0000
+            if initval is None:
+                initval = 0
+            if nextptr is None:
+                nextptr = 0
             # bitmask, player, #, modifier, nextptr
             _initval = (0xFFFFFFFF, _ProcessDest(_initval), initval, modifier, nextptr)
         self._vartrigger = VariableTriggerForward(_initval)

--- a/eudplib/core/variable/eudv.py
+++ b/eudplib/core/variable/eudv.py
@@ -89,7 +89,7 @@ class EUDVariable(VariableBase):
     """
 
     def __init__(self, _initval=0, modifier=bt.SetTo, /, initval=0, *, nextptr=0):
-        if modifier != bt.SetTo or initval is not 0 or nextptr is not 0:
+        if not (modifier == bt.SetTo and initval == 0 and nextptr == 0):
             modifier = ((bt.EncodeModifier(modifier) & 0xFF) << 24) + 0x2D0000
             # bitmask, player, #, modifier, nextptr
             _initval = (0xFFFFFFFF, _ProcessDest(_initval), initval, modifier, nextptr)

--- a/eudplib/core/variable/eudxv.py
+++ b/eudplib/core/variable/eudxv.py
@@ -29,19 +29,22 @@ from .eudv import EUDVariable, VariableTriggerForward, _ProcessDest
 
 
 class EUDXVariable(EUDVariable):
-    def __init__(self, _initval=0, modifier=None, /, initval=None, mask=None):
+    def __init__(
+        self, _initval=0, modifier=None, /, initval=None, mask=None, *, nextptr=0
+    ):
+        # bitmask, player, #, modifier, nextptr
         # value (positional)
         if modifier is None and initval is None and mask is None:
-            args = (0, bt.SetTo, _initval, ~0)
+            args = (0xFFFFFFFF, 0, _initval, 0x072D0000, nextptr)
         # value (keyword)
         elif modifier is None and mask is None:
-            args = (0, bt.SetTo, initval, ~0)
+            args = (0xFFFFFFFF, _ProcessDest(_initval), initval, 0x072D0000, nextptr)
         # value, bitmask (positional)
         elif initval is None and mask is None:
-            args = (0, bt.SetTo, _initval, modifier)
+            args = (modifier, 0, _initval, 0x072D0000, nextptr)
         # value, bitmask (keyword)
         elif modifier is None and initval is None:
-            args = (0, bt.SetTo, _initval, mask)
+            args = (mask, 0, _initval, 0x072D0000, nextptr)
         # value, bitmask, mask=bitmask (mixed)
         elif initval is None:
             raise ut.EPError(
@@ -54,8 +57,11 @@ class EUDXVariable(EUDVariable):
                 "Ambiguous initval. Use EUDXVariable(initval, mask) or EUDXVariable(player, modifier, initval, mask)"
             )
         else:
-            args = (_ProcessDest(_initval), modifier, initval, mask)
+            if mask is None:
+                mask = 0xFFFFFFFF
+            modifier = ((bt.EncodeModifier(modifier) & 0xFF) << 24) + 0x2D0000
+            args = (mask, _ProcessDest(_initval), initval, modifier, nextptr)
 
-        self._vartrigger = VariableTriggerForward(*args)
+        self._vartrigger = VariableTriggerForward(args)
         self._varact = self._vartrigger + (8 + 320)
         self._rvalue = False

--- a/eudplib/core/variable/vbuf.pyx
+++ b/eudplib/core/variable/vbuf.pyx
@@ -31,6 +31,7 @@ from ..eudobj import EUDObject
 from ... import utils as ut
 from ..allocator import RegisterCreatePayloadCallback
 from .. import rawtrigger as bt
+from collections import deque
 
 
 class EUDVarBuffer(EUDObject):
@@ -48,29 +49,15 @@ class EUDVarBuffer(EUDObject):
     def DynamicConstructed(self):
         return True
 
-    def CreateVarTrigger(
-        self, v, initval, modifier=bt.SetTo, value=None, bitmask=None):
+    def CreateVarTrigger(self, v, initval):
         ret = self + (72 * len(self._initvals))
-        if value is None:
-            initval, value = 0, initval
-        modifier = bt.EncodeModifier(modifier)
-        if bitmask is None:
-            bitmask = 0xFFFFFFFF
-        self._initvals.append((initval, modifier, value, bitmask))
+        self._initvals.append(initval)
         self._vdict[v] = ret
         return ret
 
     def CreateMultipleVarTriggers(self, v, initvals):
         ret = self + (72 * len(self._initvals))
-        for initval in initvals:
-            # initval: value | (dest, modifier, value, mask)
-            if isinstance(initval, tuple) and len(initval) == 4:
-                player, modifier, value, bitmask = initval
-                modifier = bt.EncodeModifier(modifier)
-                self._initvals.append((player, modifier, value, bitmask))
-            else:
-                modifier = bt.EncodeModifier(bt.SetTo)
-                self._initvals.append((0, modifier, initval, 0xFFFFFFFF))
+        self._initvals.extend(initvals)
         self._vdict[v] = ret
         return ret
 
@@ -78,17 +65,16 @@ class EUDVarBuffer(EUDObject):
         return 2408 + 72 * (len(self._initvals) - 1)
 
     def CollectDependency(self, emitbuffer):
-        for initvals in self._initvals:
-            for initval in initvals:
-                if (initval is not None) and type(initval) is not int:
-                    emitbuffer.WriteDword(initval)
+        for initval in self._initvals:
+            if type(initval) is not int:
+                emitbuffer.WriteDword(initval)
 
     def WritePayload(self, emitbuffer):
         cdef size_t i, heads, heade
         cdef size_t olen = 2408 + 72 * (len(self._initvals) - 1)
         cdef uint8_t * output = <uint8_t*> PyMem_Malloc(olen)
         memset(output, 0, olen)
-        cdef uint32_t bm2, pl2, iv2, mf2
+        cdef uint32_t iv2
 
         for i in range(len(self._initvals)):
             # 'preserve rawtrigger'
@@ -98,53 +84,17 @@ class EUDVarBuffer(EUDObject):
             ( < uint32_t*>(output + 72 * i + 2376))[0] = 4
 
         heads = 0
-        for i, initvals in enumerate(self._initvals):
-            player, modifier, initval, bitmask = initvals
-            heade = 72 * i + 328
-            if bitmask == 0xFFFFFFFF:
-                pass
-            elif isinstance(bitmask, int):
-                bm2 = bitmask & 0xFFFFFFFF
-                ( < uint32_t*>(output + heade))[0] = bm2
-            else:
-                emitbuffer.WriteBytes(output[heads:heade])
-                emitbuffer.WriteDword(bitmask)
-                heads = heade + 4
-
-            heade += 16
-            if player == 0:
-                pass
-            elif isinstance(player, int):
-                pl2 = player & 0xFFFFFFFF
-                ( < uint32_t*>(output + heade))[0] = pl2
-            else:
-                emitbuffer.WriteBytes(output[heads:heade])
-                emitbuffer.WriteDword(player)
-                heads = heade + 4
-
-            heade += 4
+        for i, initval in enumerate(self._initvals):
+            heade = 72 * i + 348
             if initval == 0:
-                pass
+                continue
             elif isinstance(initval, int):
                 iv2 = initval & 0xFFFFFFFF
-                ( < uint32_t*>(output + heade))[0] = iv2
-            else:
-                emitbuffer.WriteBytes(output[heads:heade])
-                emitbuffer.WriteDword(initval)
-                heads = heade + 4
-
-            heade += 4
-            if modifier == 7:  # SetTo
-                pass
-            elif isinstance(modifier, int):
-                mf2 = (0x2D0000 + (modifier << 24)) & 0xFFFFFFFF
-                ( < uint32_t*>(output + heade))[0] = mf2
-            else:
-                emitbuffer.WriteBytes(output[heads:heade])
-                emitbuffer.WriteWord(0)
-                emitbuffer.WriteByte(0x2D)
-                emitbuffer.WriteByte(modifier)
-                heads = heade + 4
+                (<uint32_t*>(output + heade))[0] = iv2
+                continue
+            emitbuffer.WriteBytes(output[heads:heade])
+            emitbuffer.WriteDword(initval)
+            heads = heade + 4
 
         emitbuffer.WriteBytes(output[heads:olen])
         PyMem_Free(output)
@@ -163,3 +113,134 @@ def GetCurrentVariableBuffer():
 
 
 RegisterCreatePayloadCallback(RegisterNewVariableBuffer)
+
+
+class EUDCustomVarBuffer(EUDObject):
+    """Customizable Variable buffer
+
+    72 bytes per variable.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self._vdict = {}
+        self._5nptrs = deque([], maxlen=5)
+        self._actnptr_pairs = []
+        self._5acts = deque([], maxlen=5)
+
+    def DynamicConstructed(self):
+        return True
+
+    def CreateVarTrigger(self, v, initval):
+        # bitmask, player, #, modifier, nptr
+        ret = self + 72 * (len(self._actnptr_pairs) + len(self._5acts))
+        if len(self._5acts) == 5:
+            act = self._5acts.popleft()
+            act.append(initval[4])
+            self._actnptr_pairs.append(act)
+        else:
+            self._5nptrs.append(initval[4])
+        self._5acts.append(deque(initval[0:4], maxlen=5))
+        if v is not None:
+            self._vdict[v] = ret
+        return ret
+
+    def CreateMultipleVarTriggers(self, v, initvals):
+        ret = self + 72 * (len(self._actnptr_pairs) + len(self._5acts))
+        for initval in initvals:
+            self.CreateVarTrigger(None, initval)
+        self._vdict[v] = ret
+        return ret
+
+    def GetDataSize(self):
+        return 2408 + 72 * (len(self._actnptr_pairs) + len(self._5acts) - 1)
+
+    def CollectDependency(self, emitbuffer):
+        for initval in self._5nptrs:
+            if type(initval) is not int:
+                emitbuffer.WriteDword(initval)
+        for initvals in self._actnptr_pairs:
+            for initval in initvals:
+                if type(initval) is not int:
+                    emitbuffer.WriteDword(initval)
+        for initvals in self._5acts:
+            for initval in initvals:
+                if type(initval) is not int:
+                    emitbuffer.WriteDword(initval)
+
+    def WritePayload(self, emitbuffer):
+        cdef size_t i, heads, heade
+        cdef size_t olen = 2408 + 72 * (len(self._actnptr_pairs) + len(self._5acts) - 1)
+        cdef uint8_t * output = <uint8_t*> PyMem_Malloc(olen)
+        memset(output, 0, olen)
+        cdef uint32_t iv2
+
+        for i in range(len(self._actnptr_pairs) + len(self._5acts)):
+            # 'preserve rawtrigger'
+            ( < uint32_t*>(output + 72 * i + 328))[0] = 0xFFFFFFFF
+            ( < uint32_t*>(output + 72 * i + 352))[0] = 0x072D0000
+            ( < uint32_t*>(output + 72 * i + 356))[0] = 0x43530000
+            ( < uint32_t*>(output + 72 * i + 2376))[0] = 4
+
+        heads = 0
+
+        for i, nptr in enumerate(self._5nptrs):
+            heade = 72 * i + 4
+            if nptr == 0:
+                continue
+            elif isinstance(nptr, int):
+                iv2 = nptr & 0xFFFFFFFF
+                (<uint32_t*>(output + heade))[0] = iv2
+                continue
+            emitbuffer.WriteBytes(output[heads:heade])
+            emitbuffer.WriteDword(nptr)
+            heads = heade + 4
+
+        # bitmask, player, initval, modifier, nptr
+        offsets = (328, 344, 348, 352, 364)
+        initials = (0xFFFFFFFF, 0, 0, 0x072D0000, 0)
+        for i, initvals in enumerate(self._actnptr_pairs):
+            for initval, offset, initial in zip(initvals, offsets, initials):
+                heade = 72 * i + offset
+                if initval == initial:
+                    continue
+                elif isinstance(initval, int):
+                    iv2 = initval & 0xFFFFFFFF
+                    (<uint32_t*>(output + heade))[0] = iv2
+                    continue
+                emitbuffer.WriteBytes(output[heads:heade])
+                emitbuffer.WriteDword(initval)
+                heads = heade + 4
+
+        for initvals in self._5acts:
+            for initval, offset, initial in zip(initvals, offsets[:4], initials[:4]):
+                heade = 72 * i + offset
+                if initval == initial:
+                    continue
+                elif isinstance(initval, int):
+                    iv2 = initval & 0xFFFFFFFF
+                    (<uint32_t*>(output + heade))[0] = iv2
+                    continue
+                emitbuffer.WriteBytes(output[heads:heade])
+                emitbuffer.WriteDword(initval)
+                heads = heade + 4
+            i += 1
+
+        emitbuffer.WriteBytes(output[heads:olen])
+        PyMem_Free(output)
+
+
+_ecvb = None
+
+
+def RegisterNewCustomVariableBuffer():
+    global _ecvb
+    _ecvb = EUDCustomVarBuffer()
+
+
+def GetCurrentCustomVariableBuffer():
+    return _ecvb
+
+
+RegisterCreatePayloadCallback(RegisterNewCustomVariableBuffer)


### PR DESCRIPTION
Split `EUDVarBuffer` into simple value-only buffer and customizable buffer (`EUDCustomVarBuffer`).

- Speed up eudplib compile time: `test_unittest` build time becomes 25s -> 20s
- Add initial `nextptr` for `EUDVArray`, `EUDVariable` and `EUDXVariable`.