### PR TITLE
minor typo fix - EncodeAIScript

### DIFF
--- a/eudplib/core/rawtrigger/strenc.py
+++ b/eudplib/core/rawtrigger/strenc.py
@@ -63,7 +63,7 @@ def EncodeAIScript(ais, issueError=False):
         elif len(ais) == 4:
             return ut.b2i4(ais)
 
-    elif isinstance(s, _Unique):
+    elif isinstance(ais, _Unique):
         raise ut.EPError(_('[Warning] "{}" is not a {}').format(ais, "AIScript"))
 
     return ais


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5178544/178061394-541a3a48-18b1-4ea5-9a25-0d0f26244414.png)

Fixed minor typo that caused compilation error when using RunAIScript()