### PR TITLE
Fixed bug of `pow(a, b)`

### DIFF
--- a/eudplib/eudlib/mathf/pow.py
+++ b/eudplib/eudlib/mathf/pow.py
@@ -33,7 +33,7 @@ def _pow(a, b):
     ret, _2n = c.EUDCreateVariables(2)
     c.SetVariables([ret, _2n], [1, 1])
     # 2^n < b 인 모든 a^(2^n) 구하기
-    if cs.EUDWhile()(_2n < b):
+    if cs.EUDWhile()(_2n <= b):
         # b에 (2^n)이 있으면 답에 a^(2^n)을 곱한다
         if cs.EUDIf()(b.AtLeastX(1, _2n)):
             ret *= a


### PR DESCRIPTION
line 36 should be `if cs.EUDWhile()(_2n <= b)`, instead of `if cs.EUDWhile()(_2n < b)` The latter will return 1 when `b` is a power of 2