### PR TITLE
New feature: SCDataObjects

### DIFF
--- a/eudplib/__init__.py
+++ b/eudplib/__init__.py
@@ -137,7 +137,13 @@ from .eudlib import *
 from .maprw import *
 from .offsetmap import CSprite, CUnit, EPDCUnitMap
 from .scdata import (
-    UnitData
+    FlingyData,
+    ImageData,
+    PlayerData,
+    SpriteData,
+    UnitData,
+    UnitOrderData,
+    WeaponData,
 )
 from .trigger import *
 from .trigtrg.runtrigtrg import (

--- a/eudplib/__init__.py
+++ b/eudplib/__init__.py
@@ -136,6 +136,9 @@ from .epscript import EPS_SetDebug, EPSLoader, epsCompile
 from .eudlib import *
 from .maprw import *
 from .offsetmap import CSprite, CUnit, EPDCUnitMap
+from .scdata import (
+    UnitData
+)
 from .trigger import *
 from .trigtrg.runtrigtrg import (
     GetFirstTrigTrigger,

--- a/eudplib/offsetmap/csprite.py
+++ b/eudplib/offsetmap/csprite.py
@@ -36,7 +36,7 @@ class CSprite(EPDOffsetMap):
     prev = CSpriteMember(0x00)
     next = CSpriteMember(0x04)
     sprite = Member(0x08, MemberKind.SPRITE)
-    playerID = Member(0x0A, MemberKind.TRG_PLAYER)  # officially "creator"
+    playerID = Member(0x0A, MemberKind.PLAYER)  # officially "creator"
     # 0 <= selectionIndex <= 11.
     # Index in the selection area at bottom of screen.
     selectionIndex = Member(0x0B, MemberKind.BYTE)

--- a/eudplib/offsetmap/csprite.py
+++ b/eudplib/offsetmap/csprite.py
@@ -11,7 +11,15 @@ from .. import core as c
 from .. import utils as ut
 from ..localize import _
 from .epdoffsetmap import EPDOffsetMap, epd_cache, ptr_cache
-from .member import CSpriteMember, EnumMember, Flag, Member, MemberKind
+from .member import (
+    CSpriteMember,
+    EnumMember,
+    Flag,
+    Member,
+    MemberKind,
+    PlayerDataMember,
+    SpriteDataMember,
+)
 
 
 class CSpriteFlags(EnumMember):
@@ -35,8 +43,8 @@ class CSprite(EPDOffsetMap):
     __slots__ = "_ptr"
     prev = CSpriteMember(0x00)
     next = CSpriteMember(0x04)
-    sprite = Member(0x08, MemberKind.SPRITE)
-    playerID = Member(0x0A, MemberKind.PLAYER)  # officially "creator"
+    sprite = SpriteDataMember(0x08)
+    playerID = PlayerDataMember(0x0A)  # officially "creator"
     # 0 <= selectionIndex <= 11.
     # Index in the selection area at bottom of screen.
     selectionIndex = Member(0x0B, MemberKind.BYTE)

--- a/eudplib/offsetmap/cunit.py
+++ b/eudplib/offsetmap/cunit.py
@@ -650,8 +650,8 @@ class CUnit(EPDOffsetMap):
         # return False
 
     @classmethod
-    def get_next(cls: type[T]) -> "CUnit":
-        return CUnit.from_read(0x628438)
+    def next(cls: type[T]) -> "CUnit":
+        return CUnit.from_read(ut.EPD(0x628438))
 
     def check_buildq(self, unit_type) -> c.Condition:
         unit = c.EncodeUnit(unit_type)

--- a/eudplib/offsetmap/cunit.py
+++ b/eudplib/offsetmap/cunit.py
@@ -21,6 +21,7 @@ from .member import (
     Flag,
     Member,
     MemberKind,
+    UnitDataMember,
     UnsupportedMember,
 )
 
@@ -137,7 +138,7 @@ class CUnit(EPDOffsetMap):
     order = Member(0x04D, MemberKind.UNIT_ORDER)
     orderState = Member(0x04E, MemberKind.BYTE)
     orderSignal = Member(0x04F, MemberKind.BYTE)
-    orderUnitType = Member(0x050, MemberKind.UNIT)
+    orderUnitType = UnitDataMember(0x050)
     unknown0x52 = Member(0x052, MemberKind.WORD)  # 2-byte padding
     cooldown = Member(0x054, MemberKind.DWORD)
     orderTimer = Member(0x054, MemberKind.BYTE)
@@ -153,8 +154,8 @@ class CUnit(EPDOffsetMap):
     orderTarget = CUnitMember(0x05C)
     orderTargetUnit = CUnitMember(0x05C)
     shield = Member(0x060, MemberKind.DWORD)
-    unitID = Member(0x064, MemberKind.UNIT)
-    unitType = Member(0x064, MemberKind.UNIT)
+    unitID = UnitDataMember(0x064)
+    unitType = UnitDataMember(0x064)
     unknown0x66 = Member(0x066, MemberKind.WORD)  # 2-byte padding
     prevPlayerUnit = CUnitMember(0x068)
     nextPlayerUnit = CUnitMember(0x06C)
@@ -190,11 +191,11 @@ class CUnit(EPDOffsetMap):
     currentButtonSet = Member(0x094, MemberKind.WORD)
     isCloaked = Member(0x096, MemberKind.BOOL)
     movementState = Member(0x097, MemberKind.BYTE)
-    buildQueue1 = Member(0x098, MemberKind.UNIT)
-    buildQueue2 = Member(0x09A, MemberKind.UNIT)
-    buildQueue3 = Member(0x09C, MemberKind.UNIT)
-    buildQueue4 = Member(0x09E, MemberKind.UNIT)
-    buildQueue5 = Member(0x0A0, MemberKind.UNIT)
+    buildQueue1 = UnitDataMember(0x098)
+    buildQueue2 = UnitDataMember(0x09A)
+    buildQueue3 = UnitDataMember(0x09C)
+    buildQueue4 = UnitDataMember(0x09E)
+    buildQueue5 = UnitDataMember(0x0A0)
     buildQueue12 = Member(0x098, MemberKind.DWORD)
     buildQueue34 = Member(0x09C, MemberKind.DWORD)
     energy = Member(0x0A2, MemberKind.WORD)
@@ -240,7 +241,7 @@ class CUnit(EPDOffsetMap):
     flagSpawnFrame = Member(0x0C8, MemberKind.DWORD)  # beacon
     # building /==============================================
     addon = CUnitMember(0x0C0)
-    addonBuildType = Member(0x0C4, MemberKind.UNIT)
+    addonBuildType = UnitDataMember(0x0C4)
     upgradeResearchTime = Member(0x0C6, MemberKind.WORD)
     techType = Member(0x0C8, MemberKind.TECH)
     upgradeType = Member(0x0C9, MemberKind.UPGRADE)

--- a/eudplib/offsetmap/cunit.py
+++ b/eudplib/offsetmap/cunit.py
@@ -21,7 +21,9 @@ from .member import (
     Flag,
     Member,
     MemberKind,
+    PlayerDataMember,
     UnitDataMember,
+    UnitOrderDataMember,
     UnsupportedMember,
 )
 
@@ -91,7 +93,7 @@ class CUnit(EPDOffsetMap):
     __slots__ = "_ptr"
     # TODO: add docstring for descriptor
     prev = CUnitMember(0x000)
-    next = CUnitMember(0x004)  # link
+    get_next = CUnitMember(0x004)  # link
     # displayed value is ceil(healthPoints/256)
     hp = Member(0x008, MemberKind.DWORD)
     sprite = CSpriteMember(0x00C)
@@ -132,10 +134,10 @@ class CUnit(EPDOffsetMap):
     acceleration = Member(0x048, MemberKind.WORD)
     currentDirection2 = Member(0x04A, MemberKind.BYTE)
     velocityDirection2 = Member(0x04B, MemberKind.BYTE)  # pathing related
-    playerID = Member(0x04C, MemberKind.TRG_PLAYER)
-    owner = Member(0x04C, MemberKind.TRG_PLAYER)
-    orderID = Member(0x04D, MemberKind.UNIT_ORDER)
-    order = Member(0x04D, MemberKind.UNIT_ORDER)
+    playerID = PlayerDataMember(0x04C)
+    owner = PlayerDataMember(0x04C)
+    orderID = UnitOrderDataMember(0x04D)
+    order = UnitOrderDataMember(0x04D)
     orderState = Member(0x04E, MemberKind.BYTE)
     orderSignal = Member(0x04F, MemberKind.BYTE)
     orderUnitType = UnitDataMember(0x050)
@@ -181,7 +183,7 @@ class CUnit(EPDOffsetMap):
     unknown0x8C = Member(0x08C, MemberKind.WORD)
     rankIncrease = Member(0x08E, MemberKind.BYTE)
     killCount = Member(0x08F, MemberKind.BYTE)
-    lastAttackingPlayer = Member(0x090, MemberKind.TRG_PLAYER)
+    lastAttackingPlayer = PlayerDataMember(0x090)
     secondaryOrderTimer = Member(0x091, MemberKind.BYTE)
     AIActionFlag = Member(0x092, MemberKind.BYTE)
     # 2 = issued an order
@@ -202,8 +204,8 @@ class CUnit(EPDOffsetMap):
     buildQueueSlot = Member(0x0A4, MemberKind.BYTE)
     targetOrderSpecial = Member(0x0A5, MemberKind.BYTE)
     uniquenessIdentifier = Member(0x0A5, MemberKind.BYTE)
-    secondaryOrder = Member(0x0A6, MemberKind.UNIT_ORDER)
-    secondaryOrderID = Member(0x0A6, MemberKind.UNIT_ORDER)
+    secondaryOrder = UnitOrderDataMember(0x0A6)
+    secondaryOrderID = UnitOrderDataMember(0x0A6)
     # 0 means the building has the largest amount of fire/blood
     buildingOverlayState = Member(0x0A7, MemberKind.BYTE)
     hpGain = Member(0x0A8, MemberKind.WORD)  # buildRepairHpGain
@@ -348,7 +350,7 @@ class CUnit(EPDOffsetMap):
     # Used to tell if a unit is under psi storm	(is "stormTimer" in BWAPI)
     isUnderStorm = Member(0x11B, MemberKind.BYTE)
     irradiatedBy = CUnitMember(0x11C)
-    irradiatePlayerID = Member(0x120, MemberKind.TRG_PLAYER)
+    irradiatePlayerID = PlayerDataMember(0x120)
     # Each bit corresponds to the player who has parasited this unit
     parasiteFlags = Member(0x121, MemberKind.BYTE)
     # counts/cycles up from 0 to 7 (inclusive). See also 0x85
@@ -651,7 +653,7 @@ class CUnit(EPDOffsetMap):
         # return False
 
     @classmethod
-    def next(cls: type[T]) -> "CUnit":
+    def from_next(cls: type[T]) -> "CUnit":
         return CUnit.from_read(ut.EPD(0x628438))
 
     def check_buildq(self, unit_type) -> c.Condition:

--- a/eudplib/offsetmap/cunit.py
+++ b/eudplib/offsetmap/cunit.py
@@ -137,7 +137,7 @@ class CUnit(EPDOffsetMap):
     order = Member(0x04D, MemberKind.UNIT_ORDER)
     orderState = Member(0x04E, MemberKind.BYTE)
     orderSignal = Member(0x04F, MemberKind.BYTE)
-    orderUnitType = Member(0x050, MemberKind.TRG_UNIT)
+    orderUnitType = Member(0x050, MemberKind.UNIT)
     unknown0x52 = Member(0x052, MemberKind.WORD)  # 2-byte padding
     cooldown = Member(0x054, MemberKind.DWORD)
     orderTimer = Member(0x054, MemberKind.BYTE)
@@ -153,8 +153,8 @@ class CUnit(EPDOffsetMap):
     orderTarget = CUnitMember(0x05C)
     orderTargetUnit = CUnitMember(0x05C)
     shield = Member(0x060, MemberKind.DWORD)
-    unitID = Member(0x064, MemberKind.TRG_UNIT)
-    unitType = Member(0x064, MemberKind.TRG_UNIT)
+    unitID = Member(0x064, MemberKind.UNIT)
+    unitType = Member(0x064, MemberKind.UNIT)
     unknown0x66 = Member(0x066, MemberKind.WORD)  # 2-byte padding
     prevPlayerUnit = CUnitMember(0x068)
     nextPlayerUnit = CUnitMember(0x06C)
@@ -172,7 +172,7 @@ class CUnit(EPDOffsetMap):
     # Prevent "Your forces are under attack." on every attack
     attackNotifyTimer = Member(0x087, MemberKind.BYTE)
     # zerg buildings while morphing
-    prevUnitType = UnsupportedMember(0x088, MemberKind.TRG_UNIT)
+    prevUnitType = UnsupportedMember(0x088, MemberKind.UNIT)
     lastEventTimer = UnsupportedMember(0x08A, MemberKind.BYTE)
     # 17 = was completed (train, morph), 174 = was attacked
     lastEventColor = UnsupportedMember(0x08B, MemberKind.BYTE)
@@ -190,11 +190,11 @@ class CUnit(EPDOffsetMap):
     currentButtonSet = Member(0x094, MemberKind.WORD)
     isCloaked = Member(0x096, MemberKind.BOOL)
     movementState = Member(0x097, MemberKind.BYTE)
-    buildQueue1 = Member(0x098, MemberKind.TRG_UNIT)
-    buildQueue2 = Member(0x09A, MemberKind.TRG_UNIT)
-    buildQueue3 = Member(0x09C, MemberKind.TRG_UNIT)
-    buildQueue4 = Member(0x09E, MemberKind.TRG_UNIT)
-    buildQueue5 = Member(0x0A0, MemberKind.TRG_UNIT)
+    buildQueue1 = Member(0x098, MemberKind.UNIT)
+    buildQueue2 = Member(0x09A, MemberKind.UNIT)
+    buildQueue3 = Member(0x09C, MemberKind.UNIT)
+    buildQueue4 = Member(0x09E, MemberKind.UNIT)
+    buildQueue5 = Member(0x0A0, MemberKind.UNIT)
     buildQueue12 = Member(0x098, MemberKind.DWORD)
     buildQueue34 = Member(0x09C, MemberKind.DWORD)
     energy = Member(0x0A2, MemberKind.WORD)
@@ -240,7 +240,7 @@ class CUnit(EPDOffsetMap):
     flagSpawnFrame = Member(0x0C8, MemberKind.DWORD)  # beacon
     # building /==============================================
     addon = CUnitMember(0x0C0)
-    addonBuildType = Member(0x0C4, MemberKind.TRG_UNIT)
+    addonBuildType = Member(0x0C4, MemberKind.UNIT)
     upgradeResearchTime = Member(0x0C6, MemberKind.WORD)
     techType = Member(0x0C8, MemberKind.TECH)
     upgradeType = Member(0x0C9, MemberKind.UPGRADE)
@@ -648,6 +648,10 @@ class CUnit(EPDOffsetMap):
         )
         f_setcurpl2cpcache()
         # return False
+
+    @classmethod
+    def get_next(cls: type[T]) -> "CUnit":
+        return CUnit.from_read(0x628438)
 
     def check_buildq(self, unit_type) -> c.Condition:
         unit = c.EncodeUnit(unit_type)

--- a/eudplib/offsetmap/member.py
+++ b/eudplib/offsetmap/member.py
@@ -41,7 +41,7 @@ class MemberKind(enum.Enum):
     C_UNIT = enum.auto()
     C_SPRITE = enum.auto()
     UNIT = enum.auto()
-    TRG_PLAYER = enum.auto()
+    PLAYER = enum.auto()
     UNIT_ORDER = enum.auto()
     POSITION = enum.auto()
     POSITION_X = enum.auto()
@@ -55,7 +55,7 @@ class MemberKind(enum.Enum):
         match self:
             case MemberKind.UNIT:
                 return c.EncodeUnit(other)
-            case MemberKind.TRG_PLAYER:
+            case MemberKind.PLAYER:
                 return c.EncodePlayer(other)
             case MemberKind.UNIT_ORDER:
                 return c.EncodeUnitOrder(other)
@@ -409,4 +409,21 @@ class SCDataObjectMember(BaseMember, Generic[S], metaclass=ABCMeta):
 
 class UnitDataMember(SCDataObjectMember[scdata.UnitData],
                      data_type=scdata.UnitData, kind=MemberKind.UNIT):
+    pass
+
+class UnitOrderDataMember(SCDataObjectMember[scdata.UnitOrderData],
+                          data_type=scdata.UnitOrderData,
+                          kind=MemberKind.UNIT_ORDER):
+    pass
+
+class FlingyDataMember(SCDataObjectMember[scdata.FlingyData],
+                       data_type=scdata.FlingyData, kind=MemberKind.FLINGY):
+    pass
+
+class SpriteDataMember(SCDataObjectMember[scdata.SpriteData],
+                       data_type=scdata.SpriteData, kind=MemberKind.SPRITE):
+    pass
+
+class PlayerDataMember(SCDataObjectMember[scdata.PlayerData],
+                       data_type=scdata.PlayerData, kind=MemberKind.PLAYER):
     pass

--- a/eudplib/offsetmap/member.py
+++ b/eudplib/offsetmap/member.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final, Literal, NoReturn
 
 from .. import core as c
 from .. import ctrlstru as cs
+from .. import scdata
 from .. import utils as ut
 from ..localize import _
 from ..trigger import Trigger
@@ -28,7 +29,7 @@ class MemberKind(enum.Enum):
     BOOL = enum.auto()
     C_UNIT = enum.auto()
     C_SPRITE = enum.auto()
-    TRG_UNIT = enum.auto()
+    UNIT = enum.auto()
     TRG_PLAYER = enum.auto()
     UNIT_ORDER = enum.auto()
     POSITION = enum.auto()
@@ -41,8 +42,8 @@ class MemberKind(enum.Enum):
 
     def cast(self, other):
         match self:
-            case MemberKind.TRG_UNIT:
-                return c.EncodeUnit(other)
+            case MemberKind.UNIT:
+                return scdata.UnitData(other)
             case MemberKind.TRG_PLAYER:
                 return c.EncodePlayer(other)
             case MemberKind.UNIT_ORDER:
@@ -70,7 +71,7 @@ class MemberKind(enum.Enum):
                 return 4
             case (
                 MemberKind.WORD
-                | MemberKind.TRG_UNIT
+                | MemberKind.UNIT
                 | MemberKind.POSITION_X
                 | MemberKind.POSITION_Y
                 | MemberKind.FLINGY
@@ -101,7 +102,7 @@ class MemberKind(enum.Enum):
                 return f_cunitepdread_epd(epd)
             case MemberKind.C_SPRITE:
                 return f_epdspriteread_epd(epd)
-            case MemberKind.TRG_UNIT | MemberKind.FLINGY:
+            case MemberKind.UNIT | MemberKind.FLINGY:
                 return f_bread_epd(epd, subp)
             case MemberKind.POSITION:
                 return f_maskread_epd(

--- a/eudplib/offsetmap/member.py
+++ b/eudplib/offsetmap/member.py
@@ -43,7 +43,7 @@ class MemberKind(enum.Enum):
     def cast(self, other):
         match self:
             case MemberKind.UNIT:
-                return scdata.UnitData(other)
+                return c.EncodeUnit(other)
             case MemberKind.TRG_PLAYER:
                 return c.EncodePlayer(other)
             case MemberKind.UNIT_ORDER:
@@ -357,3 +357,24 @@ class CSpriteMember(BaseMember):
             self.kind.write_epd(instance._epd + q, r, value)
             return
         raise AttributeError
+
+class UnitDataMember(BaseMember):
+    """Descriptor for EPDOffsetMap"""
+
+    __slots__ = ()
+
+    def __init__(self, offset: int) -> None:
+        super().__init__(offset, MemberKind.UNIT)
+
+    def __get__(self, instance, owner=None) -> "scdata.UnitData | UnitDataMember":
+        from .epdoffsetmap import EPDOffsetMap
+
+        if instance is None:
+            return self
+        q, r = divmod(self.offset, 4)
+        if isinstance(instance, EPDOffsetMap):
+            return scdata.UnitData(self.kind.read_epd(instance._epd + q, r))
+        raise AttributeError
+
+    def __set__(self, instance, value) -> None:
+        return super().__set__(instance, value)

--- a/eudplib/offsetmap/member.py
+++ b/eudplib/offsetmap/member.py
@@ -377,4 +377,11 @@ class UnitDataMember(BaseMember):
         raise AttributeError
 
     def __set__(self, instance, value) -> None:
-        return super().__set__(instance, value)
+        from .epdoffsetmap import EPDOffsetMap
+
+        q, r = divmod(self.offset, 4)
+        if isinstance(instance, EPDOffsetMap):
+            value = self.kind.cast(value)
+            self.kind.write_epd(instance._epd + q, r, value)
+            return
+        raise AttributeError

--- a/eudplib/offsetmap/member.py
+++ b/eudplib/offsetmap/member.py
@@ -7,7 +7,17 @@
 
 import enum
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Final, Literal, NoReturn
+from typing import (
+    TYPE_CHECKING,
+    Final,
+    Generic,
+    Literal,
+    NoReturn,
+    TypeVar,
+    overload,
+)
+
+from typing_extensions import Self
 
 from .. import core as c
 from .. import ctrlstru as cs
@@ -19,6 +29,7 @@ from ..trigger import Trigger
 if TYPE_CHECKING:
     from .csprite import CSprite
     from .cunit import CUnit
+    from .epdoffsetmap import EPDOffsetMap
 
 
 class MemberKind(enum.Enum):
@@ -358,22 +369,32 @@ class CSpriteMember(BaseMember):
             return
         raise AttributeError
 
-class UnitDataMember(BaseMember):
+S = TypeVar("S", bound=scdata.SCDataObject)
+class SCDataObjectMember(BaseMember, Generic[S], metaclass=ABCMeta):
     """Descriptor for EPDOffsetMap"""
-
-    __slots__ = ()
+    def __init_subclass__(cls, data_type: type[S], kind: MemberKind) -> None:
+        cls.bound_data_type = data_type
+        cls.bound_kind = kind
 
     def __init__(self, offset: int) -> None:
-        super().__init__(offset, MemberKind.UNIT)
+        super().__init__(offset, self.bound_kind)
 
-    def __get__(self, instance, owner=None) -> "scdata.UnitData | UnitDataMember":
+    @overload
+    def __get__(self, instance: None, owner=None) -> Self:
+        ...
+
+    @overload
+    def __get__(self, instance: "EPDOffsetMap", owner=None) -> S:
+        ...
+
+    def __get__(self, instance, owner=None):
         from .epdoffsetmap import EPDOffsetMap
 
         if instance is None:
             return self
         q, r = divmod(self.offset, 4)
         if isinstance(instance, EPDOffsetMap):
-            return scdata.UnitData(self.kind.read_epd(instance._epd + q, r))
+            return self.bound_data_type(self.kind.read_epd(instance._epd + q, r))
         raise AttributeError
 
     def __set__(self, instance, value) -> None:
@@ -383,5 +404,9 @@ class UnitDataMember(BaseMember):
         if isinstance(instance, EPDOffsetMap):
             value = self.kind.cast(value)
             self.kind.write_epd(instance._epd + q, r, value)
-            return
-        raise AttributeError
+        else:
+            raise AttributeError
+
+class UnitDataMember(SCDataObjectMember[scdata.UnitData],
+                     data_type=scdata.UnitData, kind=MemberKind.UNIT):
+    pass

--- a/eudplib/scdata/__init__.py
+++ b/eudplib/scdata/__init__.py
@@ -6,7 +6,10 @@
 # file that should have been included as part of this package.
 
 from .flingydata import FlingyData
+from .imagedata import ImageData
+from .playerdata import PlayerData
 from .scdataobject import SCDataObject
+from .spritedata import SpriteData
 from .unitdata import UnitData
 from .unitorderdata import UnitOrderData
 from .weapondata import WeaponData
@@ -14,6 +17,9 @@ from .weapondata import WeaponData
 __all__ = [
     "SCDataObject",
     "FlingyData",
+    "ImageData",
+    "PlayerData",
+    "SpriteData",
     "UnitData",
     "UnitOrderData",
     "WeaponData",

--- a/eudplib/scdata/__init__.py
+++ b/eudplib/scdata/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+# Copyright 2024 by zzt (Defender).
+# All rights reserved.
+# This file is part of EUD python library (eudplib),
+# and is released under "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+from .scdataobject import SCDataObject
+from .unitdata import UnitData
+
+__all__ = [
+    "SCDataObject",
+    "UnitData",
+]

--- a/eudplib/scdata/flingydata.py
+++ b/eudplib/scdata/flingydata.py
@@ -5,16 +5,15 @@
 # and is released under "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 
-from .flingydata import FlingyData
+from ..core.rawtrigger import strenc
+from .member import FlingyDataMember, Member, MemberKind
 from .scdataobject import SCDataObject
-from .unitdata import UnitData
-from .unitorderdata import UnitOrderData
-from .weapondata import WeaponData
 
-__all__ = [
-    "SCDataObject",
-    "FlingyData",
-    "UnitData",
-    "UnitOrderData",
-    "WeaponData",
-]
+
+class FlingyData(SCDataObject):
+
+
+    def __init__(self, index):
+        super().__init__(strenc.EncodeUnit(index))
+
+FlingyDataMember._data_object_type = FlingyData

--- a/eudplib/scdata/flingydata.py
+++ b/eudplib/scdata/flingydata.py
@@ -6,12 +6,18 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import FlingyDataMember, Member, MemberKind
+from .member import FlingyDataMember, Member, MemberKind, SpriteDataMember
 from .scdataobject import SCDataObject
 
 
 class FlingyData(SCDataObject):
-
+    movementControl = Member(0x6C9858, MemberKind.BYTE)  # noqa: N815
+    haltDistance = Member(0x6C9930, MemberKind.DWORD)  # noqa: N815
+    acceleration = Member(0x6C9C78, MemberKind.WORD)
+    turnRadius = Member(0x6C9E20, MemberKind.BYTE)  # noqa: N815
+    topSpeed = Member(0x6C9EF8, MemberKind.DWORD)  # noqa: N815
+    # skip unused
+    sprite = spriteID = SpriteDataMember(0x6CA318)  # noqa: N815
 
     def __init__(self, index):
         super().__init__(strenc.EncodeFlingy(index))

--- a/eudplib/scdata/imagedata.py
+++ b/eudplib/scdata/imagedata.py
@@ -11,7 +11,14 @@ from .scdataobject import SCDataObject
 
 
 class ImageData(SCDataObject):
-
+    # Read only data skipped
+    drawIfCloaked = Member(0x667718, MemberKind.BOOL)
+    drawingFunction = Member(0x669E28, MemberKind.BYTE)
+    # Remapping table is skipped because it doesn't work in SC:R
+    clickable = Member(0x66C150, MemberKind.BOOL)
+    useFullIscript = Member(0x66D4D8, MemberKind.BOOL)
+    graphicsTurns = Member(0x66E860, MemberKind.BOOL)
+    iscript = iscriptID = Member(0x66EC48, MemberKind.DWORD)  # noqa: N815
 
     def __init__(self, index):
         super().__init__(strenc.EncodeImage(index))

--- a/eudplib/scdata/imagedata.py
+++ b/eudplib/scdata/imagedata.py
@@ -6,14 +6,14 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import FlingyDataMember, Member, MemberKind
+from .member import ImageDataMember, Member, MemberKind
 from .scdataobject import SCDataObject
 
 
-class FlingyData(SCDataObject):
+class ImageData(SCDataObject):
 
 
     def __init__(self, index):
-        super().__init__(strenc.EncodeFlingy(index))
+        super().__init__(strenc.EncodeImage(index))
 
-FlingyDataMember._data_object_type = FlingyData
+ImageDataMember._data_object_type = ImageData

--- a/eudplib/scdata/imagedata.py
+++ b/eudplib/scdata/imagedata.py
@@ -12,12 +12,12 @@ from .scdataobject import SCDataObject
 
 class ImageData(SCDataObject):
     # Read only data skipped
-    drawIfCloaked = Member(0x667718, MemberKind.BOOL)
-    drawingFunction = Member(0x669E28, MemberKind.BYTE)
+    drawIfCloaked = Member(0x667718, MemberKind.BOOL)  # noqa: N815
+    drawingFunction = Member(0x669E28, MemberKind.BYTE)  # noqa: N815
     # Remapping table is skipped because it doesn't work in SC:R
     clickable = Member(0x66C150, MemberKind.BOOL)
-    useFullIscript = Member(0x66D4D8, MemberKind.BOOL)
-    graphicsTurns = Member(0x66E860, MemberKind.BOOL)
+    useFullIscript = Member(0x66D4D8, MemberKind.BOOL)  # noqa: N815
+    graphicsTurns = Member(0x66E860, MemberKind.BOOL)  # noqa: N815
     iscript = iscriptID = Member(0x66EC48, MemberKind.DWORD)  # noqa: N815
 
     def __init__(self, index):

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+# Copyright 2024 by zzt (Defender).
+# All rights reserved.
+# This file is part of EUD python library (eudplib),
+# and is released under "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+import enum
+from typing import Final, Literal, Union
+
+from .. import core as c
+from .. import utils as ut
+from ..localize import _
+from . import unitdata
+from .scdataobject import SCDataObject
+
+
+class MemberKind(enum.Enum):
+    # TODO: Combine with offsetmap's MemberKind
+    # Get rid of boilerplate/duplicate codes later
+    DWORD = enum.auto()
+    WORD = enum.auto()
+    BYTE = enum.auto()
+    BOOL = enum.auto()
+    TRG_UNIT = enum.auto()
+    TRG_PLAYER = enum.auto()
+    UNIT_ORDER = enum.auto()
+    POSITION = enum.auto()
+    POSITION_X = enum.auto()
+    POSITION_Y = enum.auto()
+    FLINGY = enum.auto()
+    SPRITE = enum.auto()
+    UPGRADE = enum.auto()
+    TECH = enum.auto()
+    # More to be added!
+
+    def cast(self, other):
+        match self:
+            case MemberKind.TRG_UNIT:
+                return c.EncodeUnit(other)
+            case MemberKind.TRG_PLAYER:
+                return c.EncodePlayer(other)
+            case MemberKind.UNIT_ORDER:
+                return c.EncodeUnitOrder(other)
+            case MemberKind.FLINGY:
+                return c.EncodeFlingy(other)
+            case MemberKind.SPRITE:
+                return c.EncodeSprite(other)
+            case MemberKind.UPGRADE:
+                return c.EncodeUpgrade(other)
+            case MemberKind.TECH:
+                return c.EncodeTech(other)
+            case _:
+                return other
+
+    @property
+    def size(self) -> Literal[1, 2, 4]:
+        match self:
+            case MemberKind.DWORD | MemberKind.POSITION:
+                return 4
+            case (
+                MemberKind.WORD
+                | MemberKind.TRG_UNIT
+                | MemberKind.POSITION_X
+                | MemberKind.POSITION_Y
+                | MemberKind.FLINGY
+                | MemberKind.SPRITE
+            ):
+                return 2
+            case _:
+                return 1
+
+    def read_epd(self, epd, subp) -> ut.ExprProxy | SCDataObject:
+        from ..eudlib import memiof
+        match self.size:
+            case 4:
+                value = memiof.f_dwread_epd(epd)
+            case 2:
+                value = memiof.f_wread_epd(epd, subp)
+            case 1:
+                value = memiof.f_bread_epd(epd, subp)
+            case _:
+                raise ValueError("size of MemberKind not in 1, 2, 4")
+
+        return self.cast(value)
+
+    def write_epd(self, epd, subp, value) -> None:
+        from ..eudlib import memiof
+        match self.size:
+            case 4:
+                memiof.f_dwwrite_epd(epd, value)
+            case 2:
+                memiof.f_wwrite_epd(epd, subp, value)
+            case 1:
+                memiof.f_bwrite_epd(epd, subp, value)
+            case _:
+                raise ValueError("size of MemberKind not in 1, 2, 4")
+
+class SCDataObjectMember:
+    base_address: Final[int]
+    base_address_epd: Final[int]
+    kind: Final[MemberKind]
+
+    def __init__(self, base_address, kind: MemberKind) -> None:
+        ut.ep_assert(base_address % 4 == 0, _("Malaligned member"))
+        # ut.ep_assert(base_address % 4 + kind.size <= 4, _("Malaligned member"))
+        self.base_address = base_address
+        self.base_address_epd = ut.EPD(base_address)
+        self.kind = kind
+
+    def __get__(self, obj, objtype=None) -> Union[ut.ExprProxy, "SCDataObject"]:
+        from .scdataobject import SCDataObject
+
+        if obj is None:
+            return self
+        # TODO improve performance for the cases not divisible by 4
+        # Probably epdoffsetmap code can be referenced
+
+        if isinstance(obj, SCDataObject):
+            if self.kind.size == 4:
+                q, r = obj, 0
+            else:
+                q, r = divmod(obj * self.kind.size, 4)
+            return self.kind.read_epd(self.base_address_epd + q, r)
+        raise AttributeError("SCDataObjectMember owner not of type SCDataObject!")
+
+
+    def __set__(self, obj, value) -> None:
+        from .scdataobject import SCDataObject
+
+        if isinstance(obj, SCDataObject):
+            if self.kind.size == 4:
+                q, r = obj, 0
+            else:
+                q, r = divmod(obj * self.kind.size, 4)
+            value = self.kind.cast(value)
+            self.kind.write_epd(self.base_address_epd + q, r, value)
+            return
+        raise AttributeError

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -206,6 +206,7 @@ S = TypeVar("S", bound=SCDataObject)
 class SCDataObjectTypeMember(Member, Generic[S], metaclass=ABCMeta):
     # TODO Think of a better name?
     _data_object_type: type[S]
+    _default_kind: MemberKind
 
     def __init_subclass__(cls, kind: MemberKind) -> None:
         cls._default_kind = kind

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     # which is why those imports are marked as unused by default
     # Therefore, these F401 warnings are suppressed now
     from .flingydata import FlingyData  # noqa: F401
+    from .imagedata import ImageData
+    from .spritedata import SpriteData  # noqa: F401
     from .unitdata import UnitData  # noqa: F401
     from .unitorderdata import UnitOrderData  # noqa: F401
     from .weapondata import WeaponData  # noqa: F401
@@ -54,6 +56,8 @@ class MemberKind(enum.Enum):
     UPGRADE = enum.auto()
     TECH = enum.auto()
     WEAPON = enum.auto()
+    SPRITE = enum.auto()
+    IMAGE = enum.auto()
     # More to be added!
 
     def cast(self, other):
@@ -78,6 +82,9 @@ class MemberKind(enum.Enum):
             case MemberKind.WEAPON:
                 from . import weapondata
                 return weapondata.WeaponData(other)
+            case MemberKind.SPRITE:
+                from . import spritedata
+                return spritedata.SpriteData(other)
             case _:
                 return other
 
@@ -211,6 +218,12 @@ class SCDataObjectTypeMember(Member, Generic[M], metaclass=ABCMeta):
 class FlingyDataMember(SCDataObjectTypeMember["FlingyData"]):
     _default_kind = MemberKind.FLINGY
 
+class ImageDataMember(SCDataObjectTypeMember["ImageData"]):
+    _default_kind = MemberKind.IMAGE
+
+class SpriteDataMember(SCDataObjectTypeMember["SpriteData"]):
+    _default_kind = MemberKind.SPRITE
+
 class UnitDataMember(SCDataObjectTypeMember["UnitData"]):
     _default_kind = MemberKind.UNIT
 
@@ -219,3 +232,4 @@ class UnitOrderDataMember(SCDataObjectTypeMember["UnitOrderData"]):
 
 class WeaponDataMember(SCDataObjectTypeMember["WeaponData"]):
     _default_kind = MemberKind.WEAPON
+

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -29,7 +29,8 @@ if TYPE_CHECKING:
     # which is why those imports are marked as unused by default
     # Therefore, these F401 warnings are suppressed now
     from .flingydata import FlingyData  # noqa: F401
-    from .imagedata import ImageData
+    from .imagedata import ImageData  # noqa: F401
+    from .playerdata import PlayerData  # noqa: F401
     from .spritedata import SpriteData  # noqa: F401
     from .unitdata import UnitData  # noqa: F401
     from .unitorderdata import UnitOrderData  # noqa: F401
@@ -56,7 +57,6 @@ class MemberKind(enum.Enum):
     UPGRADE = enum.auto()
     TECH = enum.auto()
     WEAPON = enum.auto()
-    SPRITE = enum.auto()
     IMAGE = enum.auto()
     # More to be added!
 
@@ -220,6 +220,9 @@ class FlingyDataMember(SCDataObjectTypeMember["FlingyData"]):
 
 class ImageDataMember(SCDataObjectTypeMember["ImageData"]):
     _default_kind = MemberKind.IMAGE
+
+class PlayerDataMember(SCDataObjectTypeMember["PlayerData"]):
+    _default_kind = MemberKind.PLAYER
 
 class SpriteDataMember(SCDataObjectTypeMember["SpriteData"]):
     _default_kind = MemberKind.SPRITE

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -9,6 +9,7 @@ import enum
 from abc import ABCMeta
 from typing import (
     TYPE_CHECKING,
+    ClassVar,
     Final,
     Generic,
     Literal,
@@ -228,24 +229,24 @@ class SCDataObjectTypeMember(Member, Generic[S], metaclass=ABCMeta):
         return self._data_object_type(super().__get__(instance))
 
 class FlingyDataMember(SCDataObjectTypeMember["FlingyData"], kind=MemberKind.FLINGY):
-    pass
+    _data_object_type: type["FlingyData"]
+
 class ImageDataMember(SCDataObjectTypeMember["ImageData"], kind=MemberKind.IMAGE):
-    pass
+    _data_object_type: type["ImageData"]
 
 class PlayerDataMember(SCDataObjectTypeMember["PlayerData"], kind=MemberKind.PLAYER):
-    pass
+    _data_object_type: type["PlayerData"]
 
 class SpriteDataMember(SCDataObjectTypeMember["SpriteData"], kind=MemberKind.SPRITE):
-    pass
+    _data_object_type: type["SpriteData"]
 
 class UnitDataMember(SCDataObjectTypeMember["UnitData"], kind=MemberKind.UNIT):
-    pass
+    _data_object_type: type["UnitData"]
 
 class UnitOrderDataMember(
         SCDataObjectTypeMember["UnitOrderData"], kind=MemberKind.UNIT_ORDER
     ):
-    pass
+    _data_object_type: type["UnitOrderData"]
 
 class WeaponDataMember(SCDataObjectTypeMember["WeaponData"], kind=MemberKind.WEAPON):
-    _default_kind = MemberKind.WEAPON
-
+    _data_object_type: type["WeaponData"]

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -125,7 +125,7 @@ class SCDataObjectMember:
             if self.kind.size == 4:
                 q, r = instance, 0
             else:
-                q, r = divmod(instance * self.kind.size, 4)
+                q, r = c.f_div(instance * self.kind.size, 4)
             return self.kind.read_epd(self.base_address_epd + q, r)
         raise AttributeError("SCDataObjectMember owner not of type SCDataObject!")
 
@@ -137,7 +137,7 @@ class SCDataObjectMember:
             if self.kind.size == 4:
                 q, r = instance, 0
             else:
-                q, r = divmod(instance * self.kind.size, 4)
+                q, r = c.f_div(instance * self.kind.size, 4)
             value = self.kind.cast(value)
             self.kind.write_epd(self.base_address_epd + q, r, value)
             return

--- a/eudplib/scdata/member.py
+++ b/eudplib/scdata/member.py
@@ -7,7 +7,6 @@
 
 import enum
 from abc import ABCMeta
-from types import NoneType
 from typing import (
     TYPE_CHECKING,
     Final,
@@ -146,7 +145,7 @@ class Member:
         self.kind = kind
 
     @overload
-    def __get__(self, instance: NoneType, objtype=None) -> Self:
+    def __get__(self, instance: None, objtype=None) -> Self:
         ...
 
     @overload
@@ -189,25 +188,25 @@ class Member:
 
 class EnumMember(Member):
     # TODO: Implement this later
-    def __init__(self, base_address: int, kind: MemberKind) -> NoneType:
+    def __init__(self, base_address: int, kind: MemberKind) -> None:
         raise NotImplementedError("EnumMember is not implemented yet")
 
-M = TypeVar("M", bound=SCDataObject)
+S = TypeVar("S", bound=SCDataObject)
 
-class SCDataObjectTypeMember(Member, Generic[M], metaclass=ABCMeta):
+class SCDataObjectTypeMember(Member, Generic[S], metaclass=ABCMeta):
     # TODO Think of a better name?
-    _data_object_type: type[M]
+    _data_object_type: type[S]
     _default_kind: MemberKind
 
-    def __init__(self, base_address: int) -> NoneType:
+    def __init__(self, base_address: int) -> None:
         super().__init__(base_address, self._default_kind)
 
     @overload
-    def __get__(self, instance: NoneType, objtype=None) -> Self:
+    def __get__(self, instance: None, objtype=None) -> Self:
         ...
 
     @overload
-    def __get__(self, instance: SCDataObject, objtype=None) -> M:
+    def __get__(self, instance: SCDataObject, objtype=None) -> S:
         ...
 
     def __get__(self, instance, objtype=None):

--- a/eudplib/scdata/playerdata.py
+++ b/eudplib/scdata/playerdata.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# Copyright 2024 by zzt (Defender).
+# All rights reserved.
+# This file is part of EUD python library (eudplib),
+# and is released under "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+from ..core.rawtrigger import constenc
+from ..utils import unProxy
+from .member import Member, MemberKind, PlayerDataMember
+from .scdataobject import SCDataObject
+
+
+class PlayerData(SCDataObject):
+    """
+    PlayerData is special in the sense that it is not directly related to game data;
+    rather, it is intended to deal with various game state specific to players.
+    e.g. the amount of gas a player has, can be accessed via PlayerData.
+    """
+    mineral = ore = Member(0x57F0F0, MemberKind.DWORD)
+    gas = Member(0x57F120, MemberKind.DWORD)
+
+    def __init__(self, index):
+        unproxied = unProxy(index)
+        if isinstance(unproxied, int):
+            index = unproxied
+        super().__init__(constenc.EncodePlayer(index))
+
+PlayerDataMember._data_object_type = PlayerData

--- a/eudplib/scdata/scdataobject.py
+++ b/eudplib/scdata/scdataobject.py
@@ -38,4 +38,7 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
         except TypeError as e:
             raise TypeError(_("Type {} is not castable").format(cls.__name__), e)
 
+    def Evaluate(self):  # noqa: N802
+        return c.Evaluate(self._value)
+
     # TODO maybe add caching functions for better performance later

--- a/eudplib/scdata/scdataobject.py
+++ b/eudplib/scdata/scdataobject.py
@@ -23,7 +23,6 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
     SCDataObject classes support manipulation of linked data
     via member get/set.
     """
-    __slots__ = []
     dont_flatten = True
 
     @abstractmethod
@@ -35,7 +34,7 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
         super().__init__(index)
 
     @classmethod
-    def cast(cls: Self, _from) -> Self:
+    def cast(cls, _from) -> Self:
         try:
             return cls(_from)
         except TypeError as e:

--- a/eudplib/scdata/scdataobject.py
+++ b/eudplib/scdata/scdataobject.py
@@ -23,13 +23,13 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
     SCDataObject classes support manipulation of linked data
     via member get/set.
     """
-    # @abstractmethod
-    # def __init__(self, index) -> None:
-    #     if isinstance(index, c.EUDVariable):
-    #         new_index = c.EUDVariable()
-    #         new_index << index
-    #         index = new_index
-    #     super().__init__(index)
+    @abstractmethod
+    def __init__(self, index) -> None:
+        if isinstance(index, c.EUDVariable):
+            new_index = c.EUDVariable()
+            new_index << index
+            index = new_index
+        super().__init__(index)
 
     @classmethod
     def cast(cls: Self, _from) -> Self:

--- a/eudplib/scdata/scdataobject.py
+++ b/eudplib/scdata/scdataobject.py
@@ -23,6 +23,8 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
     SCDataObject classes support manipulation of linked data
     via member get/set.
     """
+    dont_flatten = True
+
     @abstractmethod
     def __init__(self, index) -> None:
         if isinstance(index, c.EUDVariable):
@@ -41,4 +43,3 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
     def Evaluate(self):  # noqa: N802
         return c.Evaluate(self._value)
 
-    # TODO maybe add caching functions for better performance later

--- a/eudplib/scdata/scdataobject.py
+++ b/eudplib/scdata/scdataobject.py
@@ -23,6 +23,7 @@ class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
     SCDataObject classes support manipulation of linked data
     via member get/set.
     """
+    __slots__ = []
     dont_flatten = True
 
     @abstractmethod

--- a/eudplib/scdata/scdataobject.py
+++ b/eudplib/scdata/scdataobject.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# Copyright 2024 by zzt (Defender).
+# All rights reserved.
+# This file is part of EUD python library (eudplib),
+# and is released under "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+
+from abc import ABCMeta, abstractmethod
+
+from typing_extensions import Self
+
+from eudplib.localize import _
+
+from .. import core as c
+from .. import utils as ut
+
+
+class SCDataObject(ut.ExprProxy, metaclass=ABCMeta):
+    """
+    SCDataObject class.
+    SCDataObjects are object which are directly related to SC data.
+    SCDataObject classes support manipulation of linked data
+    via member get/set.
+    """
+    # @abstractmethod
+    # def __init__(self, index) -> None:
+    #     if isinstance(index, c.EUDVariable):
+    #         new_index = c.EUDVariable()
+    #         new_index << index
+    #         index = new_index
+    #     super().__init__(index)
+
+    @classmethod
+    def cast(cls: Self, _from) -> Self:
+        try:
+            return cls(_from)
+        except TypeError as e:
+            raise TypeError(_("Type {} is not castable").format(cls.__name__), e)
+
+    # TODO maybe add caching functions for better performance later

--- a/eudplib/scdata/spritedata.py
+++ b/eudplib/scdata/spritedata.py
@@ -6,14 +6,14 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import FlingyDataMember, Member, MemberKind
+from .member import Member, MemberKind, SpriteDataMember
 from .scdataobject import SCDataObject
 
 
-class FlingyData(SCDataObject):
+class SpriteData(SCDataObject):
 
 
     def __init__(self, index):
-        super().__init__(strenc.EncodeFlingy(index))
+        super().__init__(strenc.EncodeSprite(index))
 
-FlingyDataMember._data_object_type = FlingyData
+SpriteDataMember._data_object_type = SpriteData

--- a/eudplib/scdata/spritedata.py
+++ b/eudplib/scdata/spritedata.py
@@ -6,12 +6,15 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import Member, MemberKind, SpriteDataMember
+from .member import ImageDataMember, Member, MemberKind, SpriteDataMember
 from .scdataobject import SCDataObject
 
 
 class SpriteData(SCDataObject):
-
+    __slots__ = []
+    # Read only data skipped
+    visible = Member(0x665C48, MemberKind.BOOL)
+    image = imageID = ImageDataMember(0x666160)  # noqa: N815
 
     def __init__(self, index):
         super().__init__(strenc.EncodeSprite(index))

--- a/eudplib/scdata/spritedata.py
+++ b/eudplib/scdata/spritedata.py
@@ -11,7 +11,6 @@ from .scdataobject import SCDataObject
 
 
 class SpriteData(SCDataObject):
-    __slots__ = []
     # Read only data skipped
     visible = Member(0x665C48, MemberKind.BOOL)
     image = imageID = ImageDataMember(0x666160)  # noqa: N815

--- a/eudplib/scdata/unitdata.py
+++ b/eudplib/scdata/unitdata.py
@@ -6,13 +6,15 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import MemberKind, SCDataObjectMember
+from .member import MemberKind, SCDataObjectMember, UnitDataMember
 from .scdataobject import SCDataObject
 
 
 class UnitData(SCDataObject):
     maxHP = hitPoints = SCDataObjectMember(0x662350, MemberKind.DWORD)  # noqa: N815
+    subunit = subunit1 = UnitDataMember(0x6607C0, MemberKind.UNIT)
 
     def __init__(self, index):
         super().__init__(strenc.EncodeUnit(index))
 
+UnitDataMember._data_object_type = UnitData

--- a/eudplib/scdata/unitdata.py
+++ b/eudplib/scdata/unitdata.py
@@ -18,7 +18,6 @@ from .scdataobject import SCDataObject
 
 
 class UnitData(SCDataObject):
-    __slots__ = []
     maxHP = hitPoints = HP = Member(0x662350, MemberKind.DWORD)  # noqa: N815
     maxAirHits = Member(0x65FC18, MemberKind.BYTE)  # noqa: N815
     gas = gasCost = Member(0x65FD00, MemberKind.WORD)  # noqa: N815

--- a/eudplib/scdata/unitdata.py
+++ b/eudplib/scdata/unitdata.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# Copyright 2024 by zzt (Defender).
+# All rights reserved.
+# This file is part of EUD python library (eudplib),
+# and is released under "MIT License Agreement". Please see the LICENSE
+# file that should have been included as part of this package.
+
+from ..core.rawtrigger import strenc
+from .member import MemberKind, SCDataObjectMember
+from .scdataobject import SCDataObject
+
+
+class UnitData(SCDataObject):
+    maxHP = hitPoints = SCDataObjectMember(0x662350, MemberKind.DWORD)  # noqa: N815
+
+    def __init__(self, index):
+        super().__init__(strenc.EncodeUnit(index))
+

--- a/eudplib/scdata/unitdata.py
+++ b/eudplib/scdata/unitdata.py
@@ -12,7 +12,7 @@ from .scdataobject import SCDataObject
 
 class UnitData(SCDataObject):
     maxHP = hitPoints = SCDataObjectMember(0x662350, MemberKind.DWORD)  # noqa: N815
-    subunit = subunit1 = UnitDataMember(0x6607C0, MemberKind.UNIT)
+    subUnit = subUnit1 = UnitDataMember(0x6607C0, MemberKind.UNIT)  # noqa: N815
 
     def __init__(self, index):
         super().__init__(strenc.EncodeUnit(index))

--- a/eudplib/scdata/unitdata.py
+++ b/eudplib/scdata/unitdata.py
@@ -6,13 +6,71 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import MemberKind, SCDataObjectMember, UnitDataMember
+from .member import (
+    FlingyDataMember,
+    Member,
+    MemberKind,
+    UnitDataMember,
+    UnitOrderDataMember,
+    WeaponDataMember,
+)
 from .scdataobject import SCDataObject
 
 
 class UnitData(SCDataObject):
-    maxHP = hitPoints = SCDataObjectMember(0x662350, MemberKind.DWORD)  # noqa: N815
+    maxHP = hitPoints = HP = Member(0x662350, MemberKind.DWORD)  # noqa: N815
+    maxAirHits = Member(0x65FC18, MemberKind.BYTE)  # noqa: N815
+    gas = gasCost = Member(0x65FD00, MemberKind.WORD)  # noqa: N815
+    armor = Member(0x65FEC8, MemberKind.BYTE)
+    whatSoundStart = Member(0x65FFB0, MemberKind.WORD)  # noqa: N815
+    AIInternal = Member(0x660178, MemberKind.BYTE)
+    mapString = Member(0x660260, MemberKind.WORD)  # noqa: N815
+    buildTime = Member(0x660428, MemberKind.WORD)  # noqa: N815
+    startDirection = Member(0x6605F0, MemberKind.BYTE)  # noqa: N815
+    broodWarFlag = Member(0x6606D8, MemberKind.BYTE)  # noqa: N815
     subUnit = subUnit1 = UnitDataMember(0x6607C0)  # noqa: N815
+    transportSpaceProvided = Member(0x660988, MemberKind.BYTE)  # noqa: N815
+    # datRequirementOffset is not implemented yet.
+    # subunit2 is unused
+    shield = shields = Member(0x660E00, MemberKind.WORD)
+    movementFlags = Member(0x660FC8, MemberKind.BYTE)  # noqa: N815
+    constructionAnimation = Member(0x6610B0, MemberKind.BYTE)  # noqa: N815
+    yesSoundEnd = Member(0x661440, MemberKind.WORD)  # noqa: N815
+    stareditAvailabilityFlags = Member(0x661528, MemberKind.WORD)  # noqa: N815
+    airWeapon = WeaponDataMember(0x6616E0)  # noqa: N815
+    # unitDimensions is not implemented yet.
+    pissedSoundEnd = Member(0x661EE8, MemberKind.WORD)  # noqa: N815
+    readySound = Member(0x661FC0, MemberKind.WORD)  # noqa: N815
+    rightClickAction = Member(0x662098, MemberKind.BYTE)  # noqa: N815
+    sizeClass = Member(0x662180, MemberKind.BYTE)  # noqa: N815
+    # AddonPlacement is not implemented yet becasue its beginning index isn't 0.
+    buildingDimensions = Member(0x662860, MemberKind.POSITION)  # noqa: N815
+    whatSoundEnd = Member(0x662BF0, MemberKind.WORD)  # noqa: N815
+    seekRange = Member(0x662DB8, MemberKind.BYTE)  # noqa: N815
+    computerInitAction = computerIdle = Member(0x662EA0, MemberKind.BYTE)  # noqa: N815
+    portrait = Member(0x662F88, MemberKind.WORD)
+    elevationLevel = Member(0x663150, MemberKind.BYTE)  # noqa: N815
+    sightRange = Member(0x663238, MemberKind.BYTE)  # noqa: N815
+    attackUnitOrder = UnitOrderDataMember(0x663320)  # noqa: N815
+    buildScore = Member(0x663408, MemberKind.WORD)  # noqa: N815
+    armorUpgrade = Member(0x6635D0, MemberKind.BYTE)  # noqa: N815
+    groundWeapon = WeaponDataMember(0x6636B8)  # noqa: N815
+    groupFlags = Member(0x6637A0, MemberKind.BYTE)  # noqa: N815
+    mineralCost = Member(0x663888, MemberKind.WORD)  # noqa: N815
+    attackMoveOrder = UnitOrderDataMember(0x663A50)  # noqa: N815
+    pissedSoundStart = Member(0x663B38, MemberKind.WORD)  # noqa: N815
+    yesSoundStart = Member(0x663C10, MemberKind.WORD)  # noqa: N815
+    supplyUsed = Member(0x663CE8, MemberKind.BYTE)  # noqa: N815
+    rank = Member(0x663DD0, MemberKind.BYTE)
+    killScore = Member(0x663EB8, MemberKind.WORD)  # noqa: N815
+    advancedFlags = Member(0x664080, MemberKind.DWORD)  # noqa: N815
+    transportSpaceRequired = Member(0x664410, MemberKind.BYTE)  # noqa: N815
+    flingy = FlingyDataMember(0x664410)
+    maxGroundHits = Member(0x6645E0, MemberKind.BYTE)  # noqa: N815
+    supplyProvided = Member(0x6646C8, MemberKind.BYTE)  # noqa: N815
+    hasShields = Member(0x6647B0, MemberKind.BOOL)  # noqa: N815
+    idleOrder = UnitOrderDataMember(0x664898)  # noqa: N815
+    # infestationUnit is not implemented yet. (different beginning index)
 
     def __init__(self, index):
         super().__init__(strenc.EncodeUnit(index))

--- a/eudplib/scdata/unitdata.py
+++ b/eudplib/scdata/unitdata.py
@@ -18,6 +18,7 @@ from .scdataobject import SCDataObject
 
 
 class UnitData(SCDataObject):
+    __slots__ = []
     maxHP = hitPoints = HP = Member(0x662350, MemberKind.DWORD)  # noqa: N815
     maxAirHits = Member(0x65FC18, MemberKind.BYTE)  # noqa: N815
     gas = gasCost = Member(0x65FD00, MemberKind.WORD)  # noqa: N815
@@ -65,7 +66,7 @@ class UnitData(SCDataObject):
     killScore = Member(0x663EB8, MemberKind.WORD)  # noqa: N815
     advancedFlags = Member(0x664080, MemberKind.DWORD)  # noqa: N815
     transportSpaceRequired = Member(0x664410, MemberKind.BYTE)  # noqa: N815
-    flingy = FlingyDataMember(0x664410)
+    flingy = FlingyDataMember(0x6644F8)
     maxGroundHits = Member(0x6645E0, MemberKind.BYTE)  # noqa: N815
     supplyProvided = Member(0x6646C8, MemberKind.BYTE)  # noqa: N815
     hasShields = Member(0x6647B0, MemberKind.BOOL)  # noqa: N815

--- a/eudplib/scdata/unitorderdata.py
+++ b/eudplib/scdata/unitorderdata.py
@@ -11,6 +11,7 @@ from .scdataobject import SCDataObject
 
 
 class UnitOrderData(SCDataObject):
+    __slots__ = []
     animation = Member(0x664D40, MemberKind.BYTE)
 
     def __init__(self, index):

--- a/eudplib/scdata/unitorderdata.py
+++ b/eudplib/scdata/unitorderdata.py
@@ -11,7 +11,6 @@ from .scdataobject import SCDataObject
 
 
 class UnitOrderData(SCDataObject):
-    __slots__ = []
     animation = Member(0x664D40, MemberKind.BYTE)
 
     def __init__(self, index):

--- a/eudplib/scdata/unitorderdata.py
+++ b/eudplib/scdata/unitorderdata.py
@@ -6,15 +6,14 @@
 # file that should have been included as part of this package.
 
 from ..core.rawtrigger import strenc
-from .member import Member, MemberKind, WeaponDataMember
+from .member import Member, MemberKind, UnitOrderDataMember
 from .scdataobject import SCDataObject
 
 
-class WeaponData(SCDataObject):
-    damage = Member(0x656EB0, MemberKind.WORD)
-    cooldown = Member(0x656EBC, MemberKind.WORD)
+class UnitOrderData(SCDataObject):
+    animation = Member(0x664D40, MemberKind.BYTE)
 
     def __init__(self, index):
-        super().__init__(strenc.EncodeUnit(index))
+        super().__init__(strenc.EncodeUnitOrder(index))
 
-WeaponDataMember._data_object_type = WeaponData
+UnitOrderDataMember._data_object_type = UnitOrderData

--- a/eudplib/scdata/weapondata.py
+++ b/eudplib/scdata/weapondata.py
@@ -10,11 +10,11 @@ from .member import MemberKind, SCDataObjectMember, UnitDataMember
 from .scdataobject import SCDataObject
 
 
-class UnitData(SCDataObject):
-    maxHP = hitPoints = SCDataObjectMember(0x662350, MemberKind.DWORD)  # noqa: N815
-    subUnit = subUnit1 = UnitDataMember(0x6607C0)  # noqa: N815
+class WeaponData(SCDataObject):
+    damage = SCDataObjectMember(0x656EB0, MemberKind.WORD)
+    cooldown = SCDataObjectMember(0x656EBC, MemberKind.WORD)
 
     def __init__(self, index):
         super().__init__(strenc.EncodeUnit(index))
 
-UnitDataMember._data_object_type = UnitData
+UnitDataMember._data_object_type = WeaponData

--- a/eudplib/scdata/weapondata.py
+++ b/eudplib/scdata/weapondata.py
@@ -11,8 +11,33 @@ from .scdataobject import SCDataObject
 
 
 class WeaponData(SCDataObject):
+    __slots__ = []
+
+    damageFactor = Member(0x6564E0, MemberKind.BYTE)  # noqa: N815
+    targetErrorMessage = Member(0x656568, MemberKind.WORD)  # noqa: N815
+    behavior = Member(0x656670, MemberKind.BYTE)
+    effect = Member(0x6566F8, MemberKind.BYTE)
+    icon = Member(0x656780, MemberKind.WORD)
+    splashInner = splashInnerRadius = Member(0x656888, MemberKind.WORD)  # noqa: N815
+    attackAngle = Member(0x656990, MemberKind.WORD)  # noqa: N815
+    minimumRange = minRange = Member(0x656A18, MemberKind.DWORD)  # noqa: N815
+    graphicsYOffset = Member(0x656C20, MemberKind.BYTE)  # noqa: N815
+    graphics = Member(0x656CA8, MemberKind.FLINGY)
     damage = Member(0x656EB0, MemberKind.WORD)
     cooldown = Member(0x656EBC, MemberKind.WORD)
+    removeAfter = Member(0x657040, MemberKind.BYTE)  # noqa: N815
+    splashMiddle = splashMiddleRadius = Member(0x6570C8, MemberKind.WORD)  # noqa: N815
+    upgrade = upgradeID = Member(0x6571D0, MemberKind.BYTE)  # noqa: N815
+    damageType = Member(0x657258, MemberKind.BYTE)  # noqa: N815
+    label = Member(0x6572E0, MemberKind.WORD)
+    # special attack is for reference only?
+    # can't use range because it's a python keyword
+    maxRange = Member(0x6573E8, MemberKind.DWORD)  # noqa: N815
+    bonus = upgradeBonus = Member(0x657678, MemberKind.WORD)  # noqa: N815
+    splashOuter = splashOuterRadius = Member(0x657780, MemberKind.WORD)  # noqa: N815
+    launchSpin = Member(0x657888, MemberKind.BYTE)  # noqa: N815
+    graphicsXOffset = Member(0x657910, MemberKind.BYTE)  # noqa: N815
+    targetFlags = Member(0x657998, MemberKind.DWORD)  # noqa: N815
 
     def __init__(self, index):
         super().__init__(strenc.EncodeWeapon(index))

--- a/eudplib/scdata/weapondata.py
+++ b/eudplib/scdata/weapondata.py
@@ -15,6 +15,6 @@ class WeaponData(SCDataObject):
     cooldown = Member(0x656EBC, MemberKind.WORD)
 
     def __init__(self, index):
-        super().__init__(strenc.EncodeUnit(index))
+        super().__init__(strenc.EncodeWeapon(index))
 
 WeaponDataMember._data_object_type = WeaponData

--- a/eudplib/scdata/weapondata.py
+++ b/eudplib/scdata/weapondata.py
@@ -11,8 +11,6 @@ from .scdataobject import SCDataObject
 
 
 class WeaponData(SCDataObject):
-    __slots__ = []
-
     damageFactor = Member(0x6564E0, MemberKind.BYTE)  # noqa: N815
     targetErrorMessage = Member(0x656568, MemberKind.WORD)  # noqa: N815
     behavior = Member(0x656670, MemberKind.BYTE)

--- a/eudplib/utils/exprproxy.py
+++ b/eudplib/utils/exprproxy.py
@@ -73,6 +73,11 @@ class ExprProxy(Generic[T_co]):
     def __rfloordiv__(self, k):
         return k // self._value
 
+    def __divmod__(self, k):
+        div = self._value // k
+        mod = self._value % k
+        return div, mod
+
     def __mod__(self, k):
         return self._value % k
 

--- a/eudplib/utils/exprproxy.py
+++ b/eudplib/utils/exprproxy.py
@@ -15,7 +15,6 @@ T_co = TypeVar("T_co", covariant=True)
 
 class ExprProxy(Generic[T_co]):
     """Class which can contain both ConstExpr and EUDVariable"""
-
     def __init__(self, initval: T_co) -> None:
         self._value: T_co = initval
 
@@ -135,7 +134,7 @@ class ExprProxy(Generic[T_co]):
 
     # Proxy other methods
     def __getattribute__(self, name):
-        if name == "_value":
+        if name in ["_value"]:
             return super().__getattribute__(name)
         elif name == "__class__":
             return object.__getattribute__(self._value, name)

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -27,6 +27,7 @@ from unittests import (
     test_once,
     test_parse,
     test_pexists,
+    test_scdata,
     test_sq_from_1var,
     test_trace,
     test_unitgroup,

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -1,0 +1,43 @@
+# Test added by zzt (Defender)
+
+from helper import *  # noqa: F403
+
+
+@TestInstance
+def test_scdataobject():
+    test_equality("UnitData Max HP, compare against const", UnitData(0).maxHP, 40 * 256)
+
+    forty_times_256 = EUDVariable()
+    forty_times_256 << 40 * 256
+    test_equality("UnitData Max HP, compare against variable",
+                  UnitData(0).maxHP, forty_times_256)
+
+    one = EUDVariable()
+    one << 1
+    fortyfive_times_256 = EUDVariable()
+    fortyfive_times_256 << 45 * 256
+
+    ghost_data = UnitData(one)
+
+    test_equality("UnitData (variable) Max HP, compare against variable",
+                  ghost_data.maxHP, fortyfive_times_256)
+
+    # one << 2
+
+    # test_equality("UnitData (variable) Max HP, check robustness to variable change",
+    #               ghost_data.maxHP, fortyfive_times_256)
+
+    ghost_data + 3 # shouldn't raise error, but not an intended use case
+    ghost_data -= 1 # also shouldn't raise error, not an intended use case either
+
+    zealot_data = UnitData("Protoss Zealot")
+
+    zealot_data.maxHP = 80 * 256
+
+    test_equality("UnitData Max HP, check if read/write points to the same address",
+                  zealot_data.maxHP, 80 * 256)
+
+    test_equality("UnitData Max HP, check if write writes to the correct address",
+                  zealot_data.maxHP,
+                  f_dwread(0x662350 + 4 * EncodeUnit("Protoss Zealot")))
+

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -58,6 +58,9 @@ def test_scdataobject():
     test_equality("UnitData Subunit, check if member type of unit works",
                   UnitData("Terran Goliath").subUnit.maxHP, 512)
 
+    test_equality("UnitData Subunit, check if complex chain works",
+                  UnitData("Terran Goliath").subUnit.subUnit, 228)
+
     UnitData("Goliath Turret").maxHP = previous_value
 
 
@@ -66,9 +69,8 @@ def test_scdataobject():
 def test_epdoffsetmap_scdataobject_reference():
     goliath_cunit = CUnit.next()
     DoActions(CreateUnit(1, "Terran Goliath", "Anywhere", P8))
-    goliath_data = goliath_cunit.unitType
     test_equality("Cunit subunit type check",
-                  goliath_data.subUnit,
-                  UnitData("Terran Goliath").subUnit)
+                  goliath_cunit.subUnit.unitType,
+                  UnitData("Goliath Turret"))
 
     DoActions(RemoveUnit("Terran Goliath", P8))

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -63,6 +63,21 @@ def test_scdataobject():
 
     UnitData("Goliath Turret").maxHP = previous_value
 
+    DoActions(SetResources(P7, SetTo, 100, OreAndGas))
+
+    test_equality("PlayerData, check ore amount read",
+                  PlayerData(P7).mineral, 100)
+    test_equality("PlayerData, check gas amount read",
+                  PlayerData(P7).gas, 100)
+
+    PlayerData(P7).mineral += 200
+
+    test_equality("PlayerData, check ore amount write",
+                  PlayerData(P7).mineral, 300)
+    test_assert("PlayerData, check ore amount write",
+                Accumulate(P7, Exactly, 300, Ore))
+
+    DoActions(SetResources(P7, SetTo, 0, OreAndGas))
 
 
 @TestInstance

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -5,6 +5,9 @@ from helper import *  # noqa: F403
 
 @TestInstance
 def test_scdataobject():
+    test_assert("UnitData, check conversion to int", UnitData(13) == 13)
+    previous_value = EUDVariable()
+
     test_equality("UnitData Max HP, compare against const", UnitData(0).maxHP, 40 * 256)
 
     forty_times_256 = EUDVariable()
@@ -32,6 +35,7 @@ def test_scdataobject():
 
     zealot_data = UnitData("Protoss Zealot")
 
+    previous_value = zealot_data.maxHP
     zealot_data.maxHP = 80 * 256
 
     test_equality("UnitData Max HP, check if read/write points to the same address",
@@ -41,3 +45,20 @@ def test_scdataobject():
                   zealot_data.maxHP,
                   f_dwread(0x662350 + 4 * EncodeUnit("Protoss Zealot")))
 
+    zealot_data.maxHP = previous_value
+
+    previous_value = UnitData("Goliath Turret").maxHP
+    UnitData("Goliath Turret").maxHP = 512
+
+    test_equality("UnitData Subunit, check UnitData to int conversion",
+                  unProxy(UnitData("Terran Goliath").subunit),
+                  EncodeUnit("Goliath Turret"))
+
+    test_equality("UnitData Subunit, check if member type of unit works",
+                  UnitData("Terran Goliath").subunit.maxHP, 512)
+
+    UnitData("Goliath Turret").maxHP = previous_value
+
+@TestInstance
+def test_epdoffsetmap_scdataobject_reference():
+    pass

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -82,7 +82,7 @@ def test_scdataobject():
 
 @TestInstance
 def test_epdoffsetmap_scdataobject_reference():
-    goliath_cunit = CUnit.get_next()
+    goliath_cunit = CUnit.from_next()
     DoActions(CreateUnit(1, "Terran Goliath", "Anywhere", P8))
     test_equality("Cunit subunit type check",
                   goliath_cunit.subUnit.unitType,

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -58,8 +58,36 @@ def test_scdataobject():
     test_equality("UnitData Subunit, check if member type of unit works",
                   UnitData("Terran Goliath").subUnit.maxHP, 512)
 
-    test_equality("UnitData Subunit, check if complex chain works",
+    test_equality("UnitData Subunit, check if chain works",
                   UnitData("Terran Goliath").subUnit.subUnit, 228)
+
+    test_equality("UnitData, check if chain through other data types works",
+                  UnitData("Protoss Dragoon").flingy,
+                  EncodeFlingy("Dragoon"))
+
+    test_equality("UnitData, check if chain through other data types works",
+                  UnitData("Zerg Zergling").flingy.sprite,
+                  EncodeSprite("Zergling"))
+
+    test_equality("UnitData, check if chain through other data types works",
+                  UnitData("Terran Marine").flingy.sprite.image,
+                  EncodeImage("Marine"))
+
+    archon_variable = EUDVariable()
+    archon_variable << EncodeUnit("Protoss Archon")
+    archon = UnitData(archon_variable)
+
+    test_equality("UnitData, check if chain from variable works",
+                  archon.flingy,
+                  EncodeFlingy("Archon Energy"))
+
+    test_equality("UnitData, check if chain from variable works",
+                  archon.flingy.sprite,
+                  EncodeSprite("Archon Energy"))
+
+    test_equality("UnitData, check if chain from variable works",
+                  archon.flingy.sprite.image,
+                  EncodeImage("Archon Energy"))
 
     UnitData("Goliath Turret").maxHP = previous_value
 
@@ -78,6 +106,9 @@ def test_scdataobject():
                 Accumulate(P7, Exactly, 300, Ore))
 
     DoActions(SetResources(P7, SetTo, 0, OreAndGas))
+
+    with expect_eperror():
+        u = UnitData("Artanis, GOD OF EUD")
 
 
 @TestInstance

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -52,11 +52,11 @@ def test_scdataobject():
     UnitData("Goliath Turret").maxHP = 512
 
     test_equality("UnitData Subunit, check UnitData to int conversion",
-                  unProxy(UnitData("Terran Goliath").subunit),
+                  unProxy(UnitData("Terran Goliath").subUnit),
                   EncodeUnit("Goliath Turret"))
 
     test_equality("UnitData Subunit, check if member type of unit works",
-                  UnitData("Terran Goliath").subunit.maxHP, 512)
+                  UnitData("Terran Goliath").subUnit.maxHP, 512)
 
     UnitData("Goliath Turret").maxHP = previous_value
 
@@ -64,4 +64,11 @@ def test_scdataobject():
 
 @TestInstance
 def test_epdoffsetmap_scdataobject_reference():
-    pass
+    goliath_cunit = CUnit.next()
+    DoActions(CreateUnit(1, "Terran Goliath", "Anywhere", P8))
+    goliath_data = goliath_cunit.unitID
+    test_equality("Cunit subunit type check",
+                  unProxy(goliath_data.subUnit),
+                  unProxy(UnitData("Terran Goliath").subUnit))
+    
+    DoActions(RemoveUnit("Terran Goliath", P8))

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -5,7 +5,8 @@ from helper import *  # noqa: F403
 
 @TestInstance
 def test_scdataobject():
-    test_assert("UnitData, check conversion to int", UnitData(13) == 13)
+    test_equality("UnitData, check conversion to int",
+                  unProxy(UnitData(13)), 13)
     previous_value = EUDVariable()
 
     test_equality("UnitData Max HP, compare against const", UnitData(0).maxHP, 40 * 256)
@@ -58,6 +59,8 @@ def test_scdataobject():
                   UnitData("Terran Goliath").subunit.maxHP, 512)
 
     UnitData("Goliath Turret").maxHP = previous_value
+
+
 
 @TestInstance
 def test_epdoffsetmap_scdataobject_reference():

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -82,7 +82,7 @@ def test_scdataobject():
 
 @TestInstance
 def test_epdoffsetmap_scdataobject_reference():
-    goliath_cunit = CUnit.next()
+    goliath_cunit = CUnit.get_next()
     DoActions(CreateUnit(1, "Terran Goliath", "Anywhere", P8))
     test_equality("Cunit subunit type check",
                   goliath_cunit.subUnit.unitType,

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -22,10 +22,10 @@ def test_scdataobject():
     test_equality("UnitData (variable) Max HP, compare against variable",
                   ghost_data.maxHP, fortyfive_times_256)
 
-    # one << 2
+    one << 2
 
-    # test_equality("UnitData (variable) Max HP, check robustness to variable change",
-    #               ghost_data.maxHP, fortyfive_times_256)
+    test_equality("UnitData (variable) Max HP, check robustness to variable change",
+                  ghost_data.maxHP, fortyfive_times_256)
 
     ghost_data + 3 # shouldn't raise error, but not an intended use case
     ghost_data -= 1 # also shouldn't raise error, not an intended use case either

--- a/tests/unittests/test_scdata.py
+++ b/tests/unittests/test_scdata.py
@@ -6,7 +6,7 @@ from helper import *  # noqa: F403
 @TestInstance
 def test_scdataobject():
     test_equality("UnitData, check conversion to int",
-                  unProxy(UnitData(13)), 13)
+                  UnitData(13), 13)
     previous_value = EUDVariable()
 
     test_equality("UnitData Max HP, compare against const", UnitData(0).maxHP, 40 * 256)
@@ -52,7 +52,7 @@ def test_scdataobject():
     UnitData("Goliath Turret").maxHP = 512
 
     test_equality("UnitData Subunit, check UnitData to int conversion",
-                  unProxy(UnitData("Terran Goliath").subUnit),
+                  UnitData("Terran Goliath").subUnit,
                   EncodeUnit("Goliath Turret"))
 
     test_equality("UnitData Subunit, check if member type of unit works",
@@ -66,9 +66,9 @@ def test_scdataobject():
 def test_epdoffsetmap_scdataobject_reference():
     goliath_cunit = CUnit.next()
     DoActions(CreateUnit(1, "Terran Goliath", "Anywhere", P8))
-    goliath_data = goliath_cunit.unitID
+    goliath_data = goliath_cunit.unitType
     test_equality("Cunit subunit type check",
-                  unProxy(goliath_data.subUnit),
-                  unProxy(UnitData("Terran Goliath").subUnit))
-    
+                  goliath_data.subUnit,
+                  UnitData("Terran Goliath").subUnit)
+
     DoActions(RemoveUnit("Terran Goliath", P8))


### PR DESCRIPTION
Proposing the new SCDataObject classes and its subclasses:

FlingyData, ImageData, PlayerData, SpriteData, UnitData, UnitOrderData, and WeaponData.

### Motivation

Currently it's surprisingly difficult to manipulate SC data via code(eps/plib).
For example, suppose we want to increase Fragmentation Grenade's damage by 1.

We have to find the address (0x656EB0) and size (2) of the weapon damage amount offset, and need to write in the offset.
```js
const offset = 0x656EB0 + EncodeWeapon("Fragmentation Grenade") * 2;
wwrite(offset, wread(offset) + 1);

```
In this code, the only thing that makes sense (in terms of understanding the code by reading) is the `EncodeWeapon` part. What is 0x656EB0 supposed to do? Why * 2? While [eps-server](https://marketplace.visualstudio.com/items?itemName=zuhanit.eps-server) provides some information for offsets, this is far from being a comfortable coding experience.

Some mapmakers have built their own libraries to solve this issue - for example, one may have built a library that roughly works like this.
```js
import weaponutil;
weaponutil.addWeaponDamage("Fragmentation Grenade", 1);
```
Better, but this is not without limitations. What if we want to add damage of the weapon currently equipped by Marine, instead of a fixed weapon?

```js
import datautil;
const current_weapon = datautil.getUnitGroundWeapon("Terran Marine");
datautil.addWeaponDamage(current_weapon, 1);
```
Does it need to be this complex?

### Proposed Solution

What if the above code can be reduced into this?

```js
UnitData("Terran Marine").groundWeapon.damage += 1;
```
This is where the new SCDataObject classes and subclasses kick in. Those classes have members which makes data manipulation related to a specific object much easier, similar to how CUnit class makes CUnit offset manipulation much easier.

### Changes

1. The following classes are added under eudplib.scdata: `FlingyData, ImageData, PlayerData, SpriteData, UnitData, UnitOrderData, WeaponData`. Those classes are also included in the top level `__init__`.
- PlayerData currently has only `ore` and `gas` members which can be used to fetch the amount of resources a player has. 

2. Some of the CUnit members and CSprite members are updated to return the corresponding SCDataObject instance from `__get__`. For example, CUnit.unitID will now return UnitData, allowing for uses such as `CUnit(EPD(0x59CCA8)).unitID.maxHP = 80;`

3. CUnit has an additional class method: from_next(). CUnit.from_next gives the CUnit of the next unit to be created. It is currently the same as `CUnit.from_read(EPD(0x628438))`.


### Todo

- [ ] Replace the current implementation of classes such as TrgUnit, Weapon, etc. into their SCData counterparts. This will allow for much smoother epScript usage, such as `$U("Terran Marine").maxHP += 512;`

- [ ] Better support of Enum/Flag type members.

- [ ] Add more PlayerData members.

- [ ] Test many of the proposed members. Only some of the members have been tested.

- [ ] Check how eps-server works with this new feature.
