### PR TITLE
Fix eudplib install error on macOS

### DIFF
--- a/src/rust/eudplib-stormlib/src/lib.rs
+++ b/src/rust/eudplib-stormlib/src/lib.rs
@@ -121,7 +121,7 @@ impl Archive {
         replace_existing: bool,
     ) -> Result<()> {
         #[cfg(not(target_os = "windows"))]
-        let cpath = {
+        let cfile_path = {
             let pathstr = file_path
                 .as_ref()
                 .to_str()


### PR DESCRIPTION
This fixes error while install eudplib on non-windows platform, referred https://github.com/armoha/euddraft/issues/152#issuecomment-2509471059.
