### PR TITLE
Using direct cstring header

### DIFF
--- a/src/epscript/parser/parserUtils.cpp
+++ b/src/epscript/parser/parserUtils.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <regex>
 #include <iostream>
+#include <cstring>
 
 #include "generator/pygen.h"
 #include "generator/eudplibGlobals.h"


### PR DESCRIPTION
This fixes https://github.com/armoha/euddraft/issues/158, using direct included header `<cstring>`.

# Reference 
Direct vs indirect headers https://learn.microsoft.com/en-us/cpp/ide/include-cleanup-overview?view=msvc-170
https://stackoverflow.com/questions/27864276/how-to-prevent-clang-from-automatically-including-header-files
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf10-avoid-dependencies-on-implicitly-included-names