### PR TITLE
chore: add type hint in qgc

### DIFF
--- a/src/eudplib/qgc/qgc.py
+++ b/src/eudplib/qgc/qgc.py
@@ -4,6 +4,8 @@
 # and is released under "MIT License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 
+from typing import Any
+
 from .. import core as c
 from .. import ctrlstru as cs
 from ..memio import (
@@ -34,7 +36,7 @@ def _get_cmdqlen():
     return _cmdqlen
 
 
-def _set_cmdqlen(new_len):
+def _set_cmdqlen(new_len: c.EUDVariable) -> None:
     ep_assert(c.IsEUDVariable(new_len), "new command queue length can't be constant")
     c.VProc(
         [new_len, _cmdqlen],
@@ -47,7 +49,7 @@ def _set_cmdqlen(new_len):
 
 
 class QueueGameCommandHelper:
-    def __init__(self, size):
+    def __init__(self, size: int):
         self.size = size
 
     def __enter__(self):
@@ -56,14 +58,16 @@ class QueueGameCommandHelper:
         if cs.EUDIfNot()(c.Memory(_PROV_MAXBUFFER, c.AtMost, self.new_len + 1)):
             return self
 
-    def __exit__(self, exception_type, exception_value, exception_traceback):
+    def __exit__(
+        self, exception_type: Any, exception_value: Any, exception_traceback: Any
+    ):
         if exception_type is None:
             _set_cmdqlen(self.new_len)
             cs.EUDEndIf()
 
 
 @c.EUDFunc
-def QueueGameCommand(data, size):  # noqa: N802
+def QueueGameCommand(data: c.Db, size: int):  # noqa: N802
     """Queue game command to packet queue.
 
     Starcraft periodically broadcasts game packets to other player. Game
@@ -87,7 +91,9 @@ bw = EUDByteWriter()
 
 
 @c.EUDFunc
-def _qgc_alphaids(packet_id, n, arr_epd):
+def _qgc_alphaids(
+    packet_id: int | c.EUDVariable, n: int, arr_epd: int | c.EUDVariable | c.ConstExpr
+) -> None:
     """
     == 0x0B - Select Delta Del ==
     == 0x0A - Select Delta Add ==
@@ -150,7 +156,9 @@ def _qgc_alphaids(packet_id, n, arr_epd):
         f_setcurpl2cpcache()
 
 
-def QueueGameCommand_Select(n, ptr_arr):  # noqa: N802
+def QueueGameCommand_Select(
+    n: int, ptr_arr: int | c.EUDVariable | c.ConstExpr
+):  # noqa: N802
     """
     == 0x09 - Select Units ==
     {{{
@@ -166,7 +174,9 @@ def QueueGameCommand_Select(n, ptr_arr):  # noqa: N802
         _qgc_alphaids(0x09, n, EPD(ptr_arr))
 
 
-def QueueGameCommand_AddSelect(n, ptr_arr):  # noqa: N802
+def QueueGameCommand_AddSelect(
+    n: int, ptr_arr: int | c.EUDVariable | c.ConstExpr
+):  # noqa: N802
     """
     == 0x0A - Select Delta Add ==
     {{{
@@ -182,7 +192,9 @@ def QueueGameCommand_AddSelect(n, ptr_arr):  # noqa: N802
         _qgc_alphaids(0x0A, n, EPD(ptr_arr))
 
 
-def QueueGameCommand_RemoveSelect(n, ptr_arr):  # noqa: N802
+def QueueGameCommand_RemoveSelect(
+    n: int, ptr_arr: int | c.EUDVariable | c.ConstExpr
+):  # noqa: N802
     """
     == 0x0B - Select Delta Del ==
     {{{
@@ -199,7 +211,7 @@ def QueueGameCommand_RemoveSelect(n, ptr_arr):  # noqa: N802
 
 
 @c.EUDFunc
-def QueueGameCommand_RightClick(xy):  # noqa: N802
+def QueueGameCommand_RightClick(xy: int):  # noqa: N802
     """Queue right click action.
 
     :param xy: (y * 65536) + x, where (x, y) is coordinate for right click.
@@ -210,7 +222,7 @@ def QueueGameCommand_RightClick(xy):  # noqa: N802
 
 
 @c.EUDFunc
-def QueueGameCommand_QueuedRightClick(xy):  # noqa: N802
+def QueueGameCommand_QueuedRightClick(xy: int):  # noqa: N802
     """Queue right click action.
 
     :param xy: (y * 65536) + x, where (x, y) is coordinate for right click.
@@ -221,7 +233,7 @@ def QueueGameCommand_QueuedRightClick(xy):  # noqa: N802
 
 
 @c.EUDFunc
-def QueueGameCommand_MinimapPing(xy):  # noqa: N802
+def QueueGameCommand_MinimapPing(xy: int):  # noqa: N802
     """Queue minimap ping action.
 
     :param xy: (y * 65536) + x, where (x, y) is coordinate for minimap ping.
@@ -232,8 +244,8 @@ def QueueGameCommand_MinimapPing(xy):  # noqa: N802
 
 
 @c.EUDTypedFunc([TrgUnit])
-def QueueGameCommand_TrainUnit(unit):  # noqa: N802
     train_unit_command = c.Db(b"...\x1FUU..")
+def QueueGameCommand_TrainUnit(unit: TrgUnit):  # noqa: N802
     c.SetVariables(EPD(train_unit_command + 4), unit)
     QueueGameCommand(train_unit_command + 3, 3)
 

--- a/src/eudplib/qgc/qgc.py
+++ b/src/eudplib/qgc/qgc.py
@@ -14,6 +14,7 @@ from ..memio import (
     f_memcpy,
     f_setcurpl2cpcache,
 )
+from ..core.rawtrigger.consttype import Dword
 from ..scdata import CurrentPlayer, TrgUnit
 from ..utils import EPD, ep_assert
 
@@ -49,7 +50,7 @@ def _set_cmdqlen(new_len: c.EUDVariable) -> None:
 
 
 class QueueGameCommandHelper:
-    def __init__(self, size: int):
+    def __init__(self, size: Dword):
         self.size = size
 
     def __enter__(self):
@@ -67,7 +68,7 @@ class QueueGameCommandHelper:
 
 
 @c.EUDFunc
-def QueueGameCommand(data: c.Db, size: int):  # noqa: N802
+def QueueGameCommand(data: Dword, size: Dword):  # noqa: N802
     """Queue game command to packet queue.
 
     Starcraft periodically broadcasts game packets to other player. Game
@@ -91,9 +92,7 @@ bw = EUDByteWriter()
 
 
 @c.EUDFunc
-def _qgc_alphaids(
-    packet_id: int | c.EUDVariable, n: int, arr_epd: int | c.EUDVariable | c.ConstExpr
-) -> None:
+def _qgc_alphaids(packet_id: Dword, n: Dword, arr_epd: Dword) -> None:
     """
     == 0x0B - Select Delta Del ==
     == 0x0A - Select Delta Add ==
@@ -156,9 +155,7 @@ def _qgc_alphaids(
         f_setcurpl2cpcache()
 
 
-def QueueGameCommand_Select(
-    n: int, ptr_arr: int | c.EUDVariable | c.ConstExpr
-):  # noqa: N802
+def QueueGameCommand_Select(n: Dword, ptr_arr: Dword):  # noqa: N802
     """
     == 0x09 - Select Units ==
     {{{
@@ -174,9 +171,7 @@ def QueueGameCommand_Select(
         _qgc_alphaids(0x09, n, EPD(ptr_arr))
 
 
-def QueueGameCommand_AddSelect(
-    n: int, ptr_arr: int | c.EUDVariable | c.ConstExpr
-):  # noqa: N802
+def QueueGameCommand_AddSelect(n: Dword, ptr_arr: Dword):  # noqa: N802
     """
     == 0x0A - Select Delta Add ==
     {{{
@@ -192,9 +187,7 @@ def QueueGameCommand_AddSelect(
         _qgc_alphaids(0x0A, n, EPD(ptr_arr))
 
 
-def QueueGameCommand_RemoveSelect(
-    n: int, ptr_arr: int | c.EUDVariable | c.ConstExpr
-):  # noqa: N802
+def QueueGameCommand_RemoveSelect(n: Dword, ptr_arr: Dword):  # noqa: N802
     """
     == 0x0B - Select Delta Del ==
     {{{
@@ -245,7 +238,7 @@ def QueueGameCommand_MinimapPing(xy: int):  # noqa: N802
 
 @c.EUDTypedFunc([TrgUnit])
     train_unit_command = c.Db(b"...\x1FUU..")
-def QueueGameCommand_TrainUnit(unit: TrgUnit):  # noqa: N802
+def QueueGameCommand_TrainUnit(unit: TrgUnit | str | int | c.EUDVariable):  # noqa: N802
     c.SetVariables(EPD(train_unit_command + 4), unit)
     QueueGameCommand(train_unit_command + 3, 3)
 


### PR DESCRIPTION
I am not yet familiar with this library, and I inferred the type by following the function call, so the type may be incorrect.

I used a union type because I confirmed that type conversion was performed. 

Expressions such as ``int | c.EUDVariable | c.ConstExpr`` appeared repeatedly, which caught my eye. Therefore, it seems that this part could be separated into type variables.

This may not make sense because the ``EUDFunc`` decorator overwrites the type entirely.

Might also consider adding types to decorators, referring to [PEP-612](https://peps.python.org/pep-0612/)

If the type annotation is too wrong or different from what was intended, you may close the PR.