### PR TITLE
perf: optimize EUDLoopPlayerUnit branch condition

### DIFF
--- a/src/eudplib/eudlib/utilf/listloop.py
+++ b/src/eudplib/eudlib/utilf/listloop.py
@@ -238,7 +238,7 @@ def EUDLoopPlayerUnit(player) -> Iterator[tuple[c.EUDVariable, c.EUDVariable]]: 
     ut.EUDCreateBlock("playerunitloop", first_player_unit)
     ptr, epd = f_cunitepdread_epd(ut.EPD(first_player_unit) + player)
 
-    if cs.EUDWhile()(ptr >= 1):
+    if cs.EUDWhileNot()(ptr == 0):
         next_unit, nextptr = c.Forward(), c.Forward()
         # /*0x06C*/ BW::CUnit*  nextPlayerUnit;
         # f_cunitepdread_epd(


### PR DESCRIPTION
## Summary

Replace `EUDWhile()(ptr >= 1)` with the equivalent `EUDWhileNot()(ptr == 0)` in `EUDLoopPlayerUnit`.

## Rationale

Valid unit pointers are non-zero, and the pointer becomes zero only after reaching the end of the player unit list.

`EUDWhile()(ptr >= 1)` makes the common valid-pointer case take the true path of `EUDBranch`. That path rewrites and subsequently restores the branch trigger chain.

Using `EUDWhileNot()(ptr == 0)` keeps the common valid-pointer case on the lower-cost false path. The true path is taken only once, when the end of the list is reached.

For a player with N units, this reduces the number of expensive true branch paths from N to 1 while preserving the loop behavior.