### PR TITLE
Optimize _memcpy loop branch condition

### DIFF
--- a/src/eudplib/memio/mblockio.py
+++ b/src/eudplib/memio/mblockio.py
@@ -55,7 +55,7 @@ def _memcpy(dst, src, copylen):
     br1.seekoffset(src)
     bw1.seekoffset(dst)
 
-    if cs.EUDWhile()(copylen >= 1):
+    if cs.EUDWhileNot()(copylen == 0):
         b = br1.readbyte()
         bw1.writebyte(b)
         copylen -= 1


### PR DESCRIPTION
Replace `EUDWhile()(copylen >= 1)` with the equivalent `EUDWhileNot()(copylen == 0)` so normal byte-copy iterations take the lower-cost false branch.
