### PR TITLE
Optimize f_randomize loop branch condition

### DIFF
--- a/src/eudplib/eudlib/utilf/random.py
+++ b/src/eudplib/eudlib/utilf/random.py
@@ -46,7 +46,7 @@ def f_randomize():
         actions=c.SetMemoryX(end + 328 + 24, c.SetTo, 4 << 24, 0xFF << 24),
     )
 
-    if cs.EUDWhile()(n >= 1):
+    if cs.EUDWhileNot()(n == 0):
         # _seed += _seed
         c.VProc(
             _seed,


### PR DESCRIPTION
Replace `EUDWhile()(n >= 1)` with the equivalent `EUDWhileNot()(n == 0)` so the 32 seed-generation iterations take the lower-cost false branch.
